### PR TITLE
Update installing-from-war-file.rst

### DIFF
--- a/en/maintainer-guide/installing/installing-from-war-file.rst
+++ b/en/maintainer-guide/installing/installing-from-war-file.rst
@@ -3,8 +3,11 @@
 Installing from WAR file
 ########################
 
-Download ``geonetwork.war``. Copy the WAR file in the webapp folder of Tomcat.
-If started, Tomcat will deploy the application. If not, start Tomcat.
+* Download ``geonetwork.war``. 
+* Copy the WAR file in the webapp folder of Tomcat.
+* If started, Tomcat will automatically deploy the application. If not, start Tomcat to deploy.
+
+.. note:: You need to ensure Tomcat is configured with enough memory for Geonetwork to launch. This can be be configured via the ``setenv`` script in tomcat with the appropriate memory for the JAVA_OPTS property) 
 
 
 


### PR DESCRIPTION
Adding more info about installation with war file under tomcat. Wasn't clear what the minimum amount of memory needed to run was.

The following was fine for me but might be too much detail and specific to my environment (Windows and Tomcat 8)

Under Windows. Create the following file if it doesn't exist
$TOMCAT_HOME/bin/setenv.bat

and add
set JAVA_OPTS=-Dfile.encoding=UTF-8 -Xms256m -Xmx1536m -XX:PermSize=64m -XX:MaxPermSize=256m