### PR TITLE
User Administrator Profile does not have authorisation to edit

### DIFF
--- a/en/administrator-guide/managing-users-and-groups/index.rst
+++ b/en/administrator-guide/managing-users-and-groups/index.rst
@@ -93,7 +93,6 @@ Rights associated with the roles are illustrated in detail in the list below:
     
     - Full rights on creating new users within the own group
     - Rights to change users profiles within the own group
-    - Full rights on creating/editing/ deleting new/old data within the own group
 
 #.  **Content Reviewer Profile**
 


### PR DESCRIPTION
From testing experiences we found the user administrator does not have privileges to edit metadata in his group. This is also documented like that in http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/publishing/managing-privileges.html#editing
