### PR TITLE
Update to creating-group.rst

### DIFF
--- a/en/administrator-guide/managing-users-and-groups/creating-group.rst
+++ b/en/administrator-guide/managing-users-and-groups/creating-group.rst
@@ -20,7 +20,7 @@ To create new groups you should be logged on with an account that has Administra
 #. Fill out the details. The email address will be used to send feedback on data downloads when they occur for resources that are part of the Group.
 
     .. warning:: 
-        The Name should *NOT* contain spaces! You can use the Localization panel to provide localized names for groups.
+        The Name should *NOT* contain spaces and is limited to 32 characters! You can use the Localization panel to provide localized names for groups.
 
 
 #. Click on *Save*


### PR DESCRIPTION
Added 32 character limit for names to the existing warning about not including spaces.
This will inform a user reading the manual of this size limitation until the bug is fixed or the size increased.

I will also submit a bug report that attempting to add a name that is too long results in a "Group Updated" message.