### PR TITLE
Update index.rst

### DIFF
--- a/source/maintainer-guide/installing/index.rst
+++ b/source/maintainer-guide/installing/index.rst
@@ -5,7 +5,7 @@ Installing the application
 
 .. versionadded:: 3.2
 
-GeoNetwork requires a Java 8 environment (JRE) to be installed on your system. This must be done prior to installation.
+**Important: GeoNetwork requires a Java 8 environment (JRE) to be installed on your system. Later versions of java will not work at present. This must be done prior to installation.**
 
 
 Before using |project_name| on your own computer, you need to install it.


### PR DESCRIPTION
Made it more obvious that java 8 is required and not later versions. In response to https://github.com/geonetwork/core-geonetwork/issues/4144