### PR TITLE
Search doc / Fix invalid link

### DIFF
--- a/theme/layout.html
+++ b/theme/layout.html
@@ -152,6 +152,7 @@
             VERSION:'{{ release|e }}',
             COLLAPSE_INDEX:false,
             FILE_SUFFIX:'{{ '' if no_search_suffix else file_suffix }}',
+            LINK_SUFFIX:'{{ '' if no_search_suffix else file_suffix }}',
             HAS_SOURCE:  {{ has_source|lower }}
         };
     </script>


### PR DESCRIPTION
Not sure why, but when searching links are wrong
![image](https://user-images.githubusercontent.com/1701393/82915983-baa94e00-9f71-11ea-9c91-720047c57b02.png)

LINK_SUFFIX variable looks to be missing
![image](https://user-images.githubusercontent.com/1701393/82915998-c09f2f00-9f71-11ea-81b2-5e2331a8cc02.png)

Not sure when this change happens - it used to be ok last month I think.
