### PR TITLE
Address sphinx documentation warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(SRCDIR) -j auto --no-color -q
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(SRCDIR) -W --keep-going -j auto --no-color -q
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(SRCDIR)
 

--- a/source/administrator-guide/configuring-the-catalog/csw-configuration.rst
+++ b/source/administrator-guide/configuring-the-catalog/csw-configuration.rst
@@ -6,24 +6,31 @@ Configuring CSW
 
 To get to the CSW server configuration, you must be logged on as administrator first. Open 'Settings' from the Administration page and select CSW Server configuration.
 
-By default CSW endpoint is enabled, but it can be disabled.
-
-.. figure:: img/csw-off.png
-
-The Open Geospatial Catalogue Service for the Web (OGC-CSW) service,
-is a self-describing service that allows query, update and insertion of metadata records.
-
 .. figure:: img/csw.png
 
-The service can be asked to provide a description of itself, the human who administers it and other information through a GetCapabilities request (eg. http://localhost:8080/geonetwork/srv/en/csw?request=GetCapabilities&service=CSW&version=2.0.2). This form allows you to configure the CSW server and fill out some of the properties returned in response to a GetCapabilities request.
+The CSW service provides a description of itself, the human who administers it, and other information through a `GetCapabilities` request (eg. http://localhost:8080/geonetwork/srv/en/csw?request=GetCapabilities&service=CSW&version=2.0.2). This form allows you to configure the CSW server and fill out some of the properties returned in response to a GetCapabilities request.
 
-The capabilities document is created from this template :code:`web/src/main/webapp/xml/csw/capabilities.xml`.
+Configuration options:
 
+* *CSW Enabled*: By default CSW endpoint is enabled, but it can be disabled.
 
+  .. figure:: img/csw-off.png
 
-.. _csw-configuration_inspire:
+  The Open Geospatial Catalogue Service for the Web (OGC-CSW) service,
+  is a self-describing service that allows query, update and insertion of metadata records.
 
-In order to create a custom capabilities, it is recommended to create a dedicated service metadata record (using ISO19115-3 or ISO19139 standards) and use this record to build the capabilities document from.
+* *Record to use for GetCapabilities*: The capabilities document is created using the record selected here.
+
+* *Inserted metadata is public*: By default, metadata inserted with the CSW Harvest and CSW Transaction operations is not publicly viewable. A user with the appropriate access rights could do this after the CSW Harvest and CSW Transaction operations, but this is not always convenient. If this option is checked all metatada inserted using the CSW Harvest and CSW Transaction operations will be publicly viewable.
+
+* *Create element if it does not exist when using XPath in CSW transaction.*: If not checked, only existing elements can be updated.
+
+.. _csw-configuration_service_record:
+
+Service Metadata Record
+-----------------------
+
+In order to create a custom capabilities, it is recommended to create a dedicated service metadata record (using ISO19115-3 or ISO19139 standards). This record is used to build the capabilities document using the template :code:`web/src/main/webapp/xml/csw/capabilities.xml`.
 
 When creating such record, the following information will be used to create the capabilities:
 
@@ -39,10 +46,17 @@ When creating such record, the following information will be used to create the 
 
 * Contact (from Identification > First point of contact)
 
+The service record MUST be public.
 
-The record MUST be public.
+If an error occurred while building the capabilities document from the service record, a WARNING is reported using a comment and the default capabilities is used:
+
+.. figure:: img/csw-error.png
 
 
+.. _csw-configuration_inspire:
+
+CSW Configuration for INSPIRE
+-----------------------------
 
 If your catalogue also focus on INSPIRE (see :ref:`inspire-configuration`), it may be relevant to also populate the following to properly configure your discovery service:
 
@@ -56,21 +70,6 @@ If your catalogue also focus on INSPIRE (see :ref:`inspire-configuration`), it m
 
 * metadata conformity regarding Commission regulation 1089/2010
 
-With those information the CSW can be validated using the INSPIRE validator.
-
-
-If an error occurred while building the capabilities document from the service record, a WARNING is reported using a comment and the default capabilities is used:
-
-
-.. figure:: img/csw-error.png
-
-
-
-Other configuration options:
-
-* *Inserted metadata is public*: By default, metadata inserted with the CSW Harvest and CSW Transaction operations is not publicly viewable. A user with the appropriate access rights could do this after the CSW Harvest and CSW Transaction operations, but this is not always convenient. If this option is checked all metatada inserted using the CSW Harvest and CSW Transaction operations will be publicly viewable.
-
-
-* *Create element if it does not exist when using XPath in CSW transaction.*: If not checked, only existing elements can be updated.
+With this information the CSW can be validated using the INSPIRE validator.
 
 

--- a/source/administrator-guide/configuring-the-catalog/inspire-configuration.rst
+++ b/source/administrator-guide/configuring-the-catalog/inspire-configuration.rst
@@ -6,16 +6,14 @@ Configuring for the INSPIRE Directive
 Enabling INSPIRE
 ----------------
 
-From the ``admin console`` > ``settings`` user can configure INSPIRE directive support.
-
+From the :menuselection:`admin console --> settings` user can configure INSPIRE directive support.
 
 When enabled, the INSPIRE support activate the following:
 
 - Enable indexing of INSPIRE themes and annexes (INSPIRE themes thesaurus MUST be
   added to the list of thesaurus from the INSPIRE Registry - see :ref:`managing-thesaurus`).
 
-.. image:: img/inspire-configuration.png
-
+  .. image:: img/inspire-configuration.png
 
 To configure the discovery service, a dedicated service metadata record MUST be created in order to provide a complete GetCapabilities document (:ref:`csw-configuration_inspire`).
 

--- a/source/annexes/standards/iso19139.rst
+++ b/source/annexes/standards/iso19139.rst
@@ -15,21 +15,21 @@ Geographic information -- Metadata (iso19139:2007) (iso19139)
     ISO 19115 is applicable to:
 
     - the cataloguing of all types of resources, clearinghouse activities, and the full description
-    of datasets and services;
+      of datasets and services;
 
     - geographic services, geographic datasets, dataset series, and individual geographic features
-    and feature properties.
+      and feature properties.
 
     ISO 19115 defines:
 
     - mandatory and conditional metadata sections, metadata entities, and metadata elements;
 
     - the minimum set of metadata required to serve most metadata applications (data discovery,
-    determining data fitness for use, data access, data transfer, and use of digital data and
-    services);
+      determining data fitness for use, data access, data transfer, and use of digital data and
+      services);
 
     - optional metadata elements to allow for a more extensive standard description of resources, if
-    required;
+      required;
 
     - a method for extending metadata to fit specialized needs.
 

--- a/source/api/q-search.rst
+++ b/source/api/q-search.rst
@@ -1,4 +1,4 @@
-.. _geonetwork-api:
+.. _q-search:
 
 Q Search
 ##############

--- a/source/customizing-application/editor-ui/creating-custom-editor.rst
+++ b/source/customizing-application/editor-ui/creating-custom-editor.rst
@@ -1,911 +1,1 @@
-.. _creating-custom-editor:Customizing editor##################.. _creating-custom-editor-editor:
-        
-A metadata editor configuration is defined for a specific schema plugin standard
-(see :ref:`implementing-a-schema-plugin`).
-
-The editor configuration defined the navigation menu (ie. list of views and tabs)
-for the editor, the list of fields and the type of control to use. Controls could
-be HTML type (eg. text, date) or more advanced control build using
-`AngularJS directive <https://docs.angularjs.org/guide/directive>`_.
-
-
-To build such an editor configuration user needs to know the XSD of the standard
-to properly build views, tabs and fields according to element names
-(see :code:`schemas/config-editor.xsd`). Create an editor root element and
-attach:
-
-- the schema and
-
-- namespaces for the standards
-
-
-.. code-block:: xml
-
-    <editor xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:noNamespaceSchemaLocation="../../../../../../config-editor.xsd"
-      xmlns:gn="http://www.fao.org/geonetwork"
-      xmlns:gco="http://www.isotc211.org/2005/gco"
-      xmlns:gmd="http://www.isotc211.org/2005/gmd"
-      xmlns:gmx="http://www.isotc211.org/2005/gmx"
-      xmlns:srv="http://www.isotc211.org/2005/srv"
-      xmlns:gml="http://www.opengis.net/gml"
-      xmlns:xlink="http://www.w3.org/1999/xlink">
-
-
-An editor configuration should define first some general element description and then
-a set of views with at least one.
-
-
-        Child elements:- **fields**, Optional element (see :ref:`creating-custom-editor-fields`)- **fieldsWithFieldset**, Optional element (see :ref:`creating-custom-editor-fieldsWithFieldset`)- **multilingualFields**, Optional element (see :ref:`creating-custom-editor-multilingualFields`)- **views**, Mandatory element (see :ref:`creating-custom-editor-views`).. _creating-custom-editor-fields:
-        
-Defining field type
--------------------
-
-Define the form fields type configuration. Default is simple text input.
-This list contains the list of exception which does not use a simple text input.
-The list of possible values are:
-
-- all HTML5 input type or
-
-- an AngularJS directive name. MUST starts with 'data-' and
-  could end with '-textarea' to create a textarea element.
-  It could end with '-div' if the directive does not apply
-  to the input or textarea but to the div containing it.
-
-
-An element can only have one type defined.
-
-
-.. code-block:: xml
-
-    <editor>
-     <fields>
-       <for name="gmd:abstract" use="textarea"/>
-       <for name="gco:Real" use="number"/>
-       <for name="gco:Boolean" use="checkbox"/>
-       <for name="gco:Date" use="data-gn-date-picker"/>
-
-
-The other option to define a more advanced field type is to catch the element using
-and XSL template. This approach is used for keywords in ISO19139 for example
-(see :code:`schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl`).
-
-
-        
-      .. _creating-custom-editor-fieldsWithFieldset:
-        
-
-Grouping element from the standards
------------------------------------
-
-List of element to be displayed in a fieldset (ie. boxed element). Those
-elements usually contain children elements and define major section in the
-standard. For example, in ISO19139, identification and distribution are major
-section and should usually be displayed as a group of information.
-
-.. code-block:: xml
-
-    <editor>
-       <fields>...</fields>
-       <fieldsWithFieldset>
-        <name>gmd:identificationInfo</name>
-        <name>gmd:distributionInfo</name>
-
-
-        .. _creating-custom-editor-multilingualFields:
-        
-Defining multilingual fields
-----------------------------
-
-Configure here the list of multilingual fields for a standard.
-
-By default, if the standard as multilingual support like ISO19139, all fields will be displayed
-as multilingual fields. Define in the exclude section the exception (eg. gmd:identifier for example in ISO19139).
-
-Then this section also allows to define how multilingual fields are displayed using the expanded elements.
-If expanded, then one field per language is displayed with no need to click on the language switcher.
-
-.. figure:: ../../user-guide/describing-information/img/multilingual-editing.png
-
-
-
-.. code-block:: xml
-
-
-    <editor>
-       <fields>...</fields>
-       <fieldsWithFieldset>...</fieldsWithFieldset>
-        <multilingualFields>
-          <expanded>
-            <name>gmd:title</name>
-            <name>gmd:abstract</name>
-          </expanded>
-          <exclude>
-            <name>gmd:identifier</name>
-            <name>gmd:metadataStandardName</name>
-
-
-        .. _creating-custom-editor-views:
-        
-Configuring views
------------------
-
-At least one view MUST be defined but more view modes can be defined depending on the needs.
-
-By default ISO19139 define 3 views (ie. default, advanced, xml) and one disabled (ie. INSPIRE).
-See :code:`schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml` for the configuration.
-
-.. figure:: ../../user-guide/describing-information/img/view-mode.png
-
-Another basic example is the Dublin Core view (see :code:`schemas/dublin-core/src/main/plugin/dublin-core/layout/config-editor.xml`).
-
-To create a new view, use the following:
-
-.. code-block:: xml
-
-
-      <views>
-          <view name="viewNameInLocalizationFile">
-            ...
-          </view>
-
-        
-      Child elements:- **view**, One or more (see :ref:`creating-custom-editor-view`).. _creating-custom-editor-view:
-        
-Defining a view
----------------
-
-A view has a label and define a specific rendering of the metadata records.
-A view is composed of one or more tabs.
-
-.. code-block:: xml
-
-
-      <views>
-          <view name="custom-view">
-              ....
-          </view>
-
-
-The view could be displayed or not according to the metadata record content or
-the current user session using the displayIfRecord and displayIfServiceInfo attribute.
-
-        
-      Attributes:- **name** (Mandatory)
-The key of the view name stored in ``{schema}/loc/{lang}/strings.xml`` or the element name with namespace prefix.
-
-.. code-block:: xml
-
-      <strings>
-        <default>Simple</default>
-        <inspire>INSPIRE</inspire>
-        <custom-view>My view</custom-view>
-
-
-            - **disabled** (Optional) Fixed value: **true**
-Hide the view from the menu if the attribute is defined. Allows to easily disable a view.
-            - **class** (Optional)
-Define custom CSS class to be set on the form element. This is mainly used
-to set the type of indent:
-
- * gn-label-above-input: to put label above form input
- * gn-indent-colored: colored left border on each fieldset
- * gn-indent-bluescale: blue scale colored left border on each fieldset
-
-See catalog/views/default/less/gn_editor_default.less to add your custom editor styles.
-            - **upAndDownControlHidden** (Optional) Fixed value: **true**
-Define if up and down control should be displayed in that view. If not defined, controls are displayed.
-Hide those controls in a view to make it easier with less controls for the end-user.
-
-.. figure:: ../../user-guide/describing-information/img/editor-control-updown.png
-
-
-            - **displayAttributes** (Optional) Fixed value: **true**
-Display attributes by default when loading the view.
-- **displayTooltips** (Optional) Fixed value: **true**
-Display help documentation for all elements by default when loading the view.
-- **displayTooltipsMode** (Optional)
-Display help documentation onhover elements (default) or by clicking on an icon.
-- **hideTimeInCalendar** (Optional) Fixed value: **true**
-Define if calendar control should allows users to set date only or
-datetime. If attribute is not set, then date and time can be set. This is controlled at the view level,
-switching to another view may allow more control over the dates.
-
-- **displayIfRecord** (Optional)
-XPath expression returning boolean value which will be evaluated against the metadata record. if true the view will be displayed.
-eg. Display custom-view if metadata standard name contains Medsea:
-
-.. code-block:: xml
-
-    <view name="custom-view"
-          displayIfRecord="contains(gmd:MD_Metadata/
-                                      gmd:metadataStandardName/gco:CharacterString,
-                                    'MedSea')"
-
-- **displayIfServiceInfo** (Optional)
-XPath expression returning boolean value which will be evaluate against the service
-information tree (Jeeves /root/gui element). if true the view will be displayed.
-
-eg. Display custom view if user is Administrator:
-
-.. code-block:: xml
-
-    <view name="custom-view"
-          displayIfServiceInfo="count(session[profile = 'Administrator']) = 1"
-
-displayIfRecord and displayIfServiceInfo could be combined. An AND operator is used. Both condition MUST returned true for the view to be displayed.
-
-Child elements:- **tab**, One or more (see :ref:`creating-custom-editor-tab`)- **flatModeExceptions**, Optional element (see :ref:`creating-custom-editor-flatModeExceptions`)- **thesaurusList**, Optional element (see :ref:`creating-custom-editor-thesaurusList`).. _creating-custom-editor-tab:
-
-Defining a tab
---------------
-
-A view contains at least one tab. In that case it will be the default to display and no
-top toolbar will be displayed to switch from one tab to another.
-
-.. figure:: ../../user-guide/describing-information/img/editor-tab-switcher.png
-
-Add custom view one default tab and a field for the title:
-
-.. code-block:: xml
-
-      <views>
-        <view name="custom-view">
-          <tab id="custom-tab" default="true">
-            <section>
-              <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:title"/>
-            </section>
-          </tab>
-        </view>
-
-
-
-        Attributes:- **id** (Mandatory)
-The tab key used in URL parameter to activate that tab. The key is also use for the tab label as defined in ``{schema}/loc/{lang}/strings.xml``.
-            - **default** (Optional) Fixed value: **true**
-Define if this tab is the default one for the view. Only one tab should be the default in a view.
-            - **toggle** (Optional) Fixed value: **true**
-Define if the tab should be displayed in a drop down menu instead of a tab. This is used for advanced
-section which is not used often by the end-user. More than one tab could be grouped in that drop down tab menu.
-            - **formatter-order** (Optional)
-Define the ordering index of this tab in the XSLT formatter (Note used for editor).
-            - **mode** (Optional) Fixed value: **flat**
-The "flat" mode is an important concept to understand for the editor. It controls the way:
-
- - complex elements are displayed (ie. elements having children) and
-
- - non existing elements are displayed (ie. elements in the standard not in the current document).
-
-
-When a tab is in flat mode, this tab will not display element which are not in the current metadata
-document and it will display complex element as a group only if defined in the list of
-element with fieldset (see :ref:`creating-custom-editor-fieldsWithFieldset`).
-
-Example for a contact in non "flat" mode:
-
-
-.. figure:: ../../user-guide/describing-information/img/editor-contact-nonflatmode.png
-
-
-Example for a contact in "flat" mode:
-
-
-.. figure:: ../../user-guide/describing-information/img/editor-contact-flatmode.png
-
-
-This mode makes the layout simpler but does not provide all controls to remove
-some of the usually boxed element. End-user can still move  to the advanced view mode
-to access those hidden elements in flat mode.
-
-It's recommended to preserve at least one view in non "flat" mode for reviewer or administrator in order
-to be able:
-
- - to build proper templates based on the standards
-
- - to fix any types of errors.
-
-
-        - **mode** (Mandatory)- **displayIfRecord** (Optional)
-XPath expression returning boolean value which will be evaluated against the metadata record. if true the view will be displayed.
-eg. Display custom-view if metadata standard name contains Medsea:
-
-.. code-block:: xml
-
-    <view name="custom-view"
-          displayIfRecord="contains(gmd:MD_Metadata/
-                                      gmd:metadataStandardName/gco:CharacterString,
-                                    'MedSea')"
-
-- **displayIfServiceInfo** (Optional)
-XPath expression returning boolean value which will be evaluate against the service
-information tree (Jeeves /root/gui element). if true the view will be displayed.
-
-eg. Display custom view if user is Administrator:
-
-.. code-block:: xml
-
-    <view name="custom-view"
-          displayIfServiceInfo="count(session[profile = 'Administrator']) = 1"
-
-displayIfRecord and displayIfServiceInfo could be combined. An AND operator is used. Both condition MUST returned true for the view to be displayed.
-
-.. _creating-custom-editor-flatModeExceptions:
-Configuring complex element display
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Elements to apply "flat" mode exceptions. By default,
-"flat" mode does not display elements containing only children and no value.
-
-Use or and in attribute to display non existing element.
-To display gmd:descriptiveKeywords element even if does not exist in the metadata
-record or if the field should be displayed to add new occurrences:
-
-.. code-block:: xml
-
-      <field
-            xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:descriptiveKeywords/*/gmd:keyword"
-            or="keyword"
-            in="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:descriptiveKeywords/*"/>
-   </tab>
-
-   <!-- Elements that should not use the "flat" mode -->
-   <flatModeExceptions>
-     <for name="gmd:descriptiveKeywords" />
-   </flatModeExceptions>
- </view>
-
-
-.. _creating-custom-editor-thesaurusList:
-Customizing thesaurus
-~~~~~~~~~~~~~~~~~~~~~
-
-To configure the type of transformations
-or the number of keyword allowed or if the widget
-has to be displayed in a fieldset or as simple field for e
-thesaurus define a specific configuration:
-
-eg. only 2 INSPIRE themes.
-
-
-.. code-block:: xml
-
-      <thesaurusList>
-        <thesaurus key="external.theme.httpinspireeceuropaeutheme-theme"
-                   maxtags="2"
-                   fieldset="false"
-                   transformations=""/>
-      </thesaurusList>
-
-
-      .. _creating-custom-editor-section:
-Adding a section to a tab
--------------------------
-
-A section is a group of fields. If a name attribute is provided,
-then it will create an HTML fieldset which is collapsible.
-If no name attribute is provided, then it just render the inner elements.
-For example, if you need a tab without a root fieldset, juste create 
-the mandatory section with no name and then the inner elements.
-
-
-        Attributes:- **name** (Optional)An optional name to override the default one base on field name for the
-            section. The name must be defined in ``{schema}/loc/{lang}/strings.xml``.
-          - **xpath** (Optional)The xpath of the element to match. If an XPath is set for a section, it
-            should not contains any field.
-          - **mode** (Optional) Fixed value: **flat**
-The "flat" mode is an important concept to understand for the editor. It controls the way:
-
- - complex elements are displayed (ie. elements having children) and
-
- - non existing elements are displayed (ie. elements in the standard not in the current document).
-
-
-When a tab is in flat mode, this tab will not display element which are not in the current metadata
-document and it will display complex element as a group only if defined in the list of
-element with fieldset (see :ref:`creating-custom-editor-fieldsWithFieldset`).
-
-Example for a contact in non "flat" mode:
-
-
-.. figure:: ../../user-guide/describing-information/img/editor-contact-nonflatmode.png
-
-
-Example for a contact in "flat" mode:
-
-
-.. figure:: ../../user-guide/describing-information/img/editor-contact-flatmode.png
-
-
-This mode makes the layout simpler but does not provide all controls to remove
-some of the usually boxed element. End-user can still move  to the advanced view mode
-to access those hidden elements in flat mode.
-
-It's recommended to preserve at least one view in non "flat" mode for reviewer or administrator in order
-to be able:
-
- - to build proper templates based on the standards
-
- - to fix any types of errors.
-
-
-        - **mode** (Mandatory)- **or** (Optional)Local name to match if the element does not exist.- **or** (Optional)
-            
-The local name of the geonet child (ie. non existing element) to match.
-
-.. code-block:: xml
-
-    <field xpath="/gmd:MD_Metadata/gmd:language"
-           or="language"
-           in="/gmd:MD_Metadata"/>
-
-- **or** (Optional)- **in** (Optional)XPath of the geonet:child element with the or name to look for. Usually
-        points to the parent of last element of the XPath attribute.
-      - **in** (Optional)The element to search in for the geonet child.- **displayIfRecord** (Optional)
-XPath expression returning boolean value which will be evaluated against the metadata record. if true the view will be displayed.
-eg. Display custom-view if metadata standard name contains Medsea:
-
-.. code-block:: xml
-
-    <view name="custom-view"
-          displayIfRecord="contains(gmd:MD_Metadata/
-                                      gmd:metadataStandardName/gco:CharacterString,
-                                    'MedSea')"
-
-.. _creating-custom-editor-field:
-
-Adding a field
---------------
-
-To display a simple element use the ``xpath`` attribute to point to the element to display:
-
-.. code-block:: xml
-
-      <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:title"/>
-
-
-To override a field label use the ``name`` attribute and define that new label in ``{schema}/loc/{lang}/strings.xml``:
-
-.. code-block:: xml
-
-      <field name="myTitle"
-             xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:title"/>
-
-
-To display a complex element which exist in the metadata document:
-
-.. code-block:: xml
-
-      <field name="pointOfContact"
-             xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:pointOfContact"/>
-
-In that case all children elements are also displayed.
-
-
-
-To display a field if exist in the metadata document or providing a add button
-in case it does not exist (specify ``in`` and ``or`` attribute):
-
-
-.. code-block:: xml
-
-      <field name="pointOfContact"
-             xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:pointOfContact"
-             or="pointOfContact"
-             in="/gmd:MD_Metadata/gmd:identificationInfo/*"
-             del="."/>
-
-
-Activate the "flat" mode at the tab level to make the form display only existing elements:
-
-.. code-block:: xml
-
-    <view name="custom-view">
-        <tab id="custom-tab" default="true" mode="flat">
-          <section>
-            <field
-                    xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:title"/>
-            <field name="pointOfContact"
-                   xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:pointOfContact"
-                   or="pointOfContact"
-                   in="/gmd:MD_Metadata/gmd:identificationInfo/*"
-                   del="."/>
-          </section>
-        </tab>
-      </view>
-
-
-        Attributes:- **xpath** (Mandatory)The xpath of the element to match.- **if** (Optional)
-An optional xpath expression to evaluate to define if the element should be displayed
-only in some situation (eg. only for service metadata records). eg.
-
-.. code-block:: xml
-
-          <field
-            xpath="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/
-            gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:otherConstraints"
-            if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification) > 0"/>
-
-- **name** (Optional)A field name to override the default name.- **isMissingLabel** (Optional)
-The label to display if the element does not exist in the metadata record. It indicates that
-the element is missing in the current record. It could be use for a conformity section saying
-that the element is "not evaluated". EXPERIMENTAL
-            
-          - **or** (Optional)
-            
-The local name of the geonet child (ie. non existing element) to match.
-
-.. code-block:: xml
-
-    <field xpath="/gmd:MD_Metadata/gmd:language"
-           or="language"
-           in="/gmd:MD_Metadata"/>
-
-- **in** (Optional)The element to search in for the geonet child.- **del** (Optional)
-            
-Relative XPath of the element to remove when the remove button is clicked.
-
-eg. If a template field match linkage and allows editing of field URL,
-the remove control should remove the parent element gmd:onLine.
-
-.. code-block:: xml
-
-    <field name="url"
-      xpath="/gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions
-                /gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:linkage"
-      del="../..">
-      <template>
-
-
-
-Del attribute can be used in template mode or not. Example to remove
-spatialResolution while only editing denominator or distance. Denominator or distance
-are mandatory but as the del element point to the spatialResolution
-ancestor, there is no mandatory flag displayed and the remove control
-remove the spatialResolution element.
-
-
-.. code-block:: xml
-
-
-    <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/
-                    */gmd:spatialResolution/*/gmd:distance"
-           del="../.."/>
-    <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/
-                    */gmd:spatialResolution/
-                      */gmd:equivalentScale/*/gmd:denominator"
-           del="../../../.."/>
-
-            
-          - **templateModeOnly** (Optional) Fixed value: **true**
-Define if the template mode should be the only mode used. In that case, the field is always
-displayed based on the XML template snippet field configuration. Default is false.
-            - **notDisplayedIfMissing** (Optional) Fixed value: **true**If the field is found and a geonet child also, the geonet child to add a
-            new one is not displayed.
-          - **use** (Optional)
-The form field type to use (one of the HTML5 type) or an AngularJS directive to use.
-This list is defined as an open enumeration. For directive, the value will be set in a simple
-text input by default. If the directive needs to deal with cariage return character, the
-directive name MUST contains "-textarea" in order to set the value in a textarea
-instead of the text input.
-         - **use** (Optional)
-                        
-Field type. Register here any Angular directive to be used
-on the client side. Default is simple text field.
-                        
-                      Child elements:- **template**, Optional element (see :ref:`creating-custom-editor-template`).. _creating-custom-editor-template:
-
-Adding a template based field
------------------------------
-
-A templace configuration for an XML snippet to edit.
-
-A template field is compose of an XML snippet corresponding to the element to edit where values to be edited are identified using {{fields}} notation. Each fields needs to be defined as values from which one input field will be created.
-
-This mode is used to hide the complexity of the XML element to edit. eg.
-
-.. code-block:: xml
-
-     <field name="url"
-            templateModeOnly="true"
-            xpath="/gmd:MD_Metadata/gmd:distributionInfo/g.../gmd:linkage">
-        <template>
-          <values>
-            <key label="url"
-                 xpath="gmd:URL"
-                 tooltip="gmd:linkage"/>
-          </values>
-          <snippet>t
-            <gmd:linkage>
-              <gmd:URL>{{url}}</gmd:URL>
-            </gmd:linkage>
-          </snippet>
-        </template>
-
-
-The template field mode will only provide editing of part of the snippet element. In some case the snippet may contains more elements than the one edited. In such case, the snippet MUST identified the list of potential elements in order to not to loose information when using this mode. Use the gn:copy element to properly combined the template with the current document.
-
-eg. The gmd:MD_Identifier may contain a gmd:authority node which needs to be preserved.
-
-.. code-block:: xml
-
-    <snippet>
-      <gmd:identifier>
-        <gmd:MD_Identifier>
-          <gn:copy select="gmd:authority"/>
-          <gmd:code>
-            <gco:CharacterString>{{code}}</gco:CharacterString>
-          </gmd:code>
-        </gmd:MD_Identifier>
-      </gmd:identifier>
-    </snippet>
-
-Warning: Template based field does not support multilingual editing for ISO standards (ie. only the main language is edited - therefore, multilingual elements will be preserved).
-
-
-        .. _creating-custom-editor-text:
-Adding documentation or help
-----------------------------
-
-Insert an HTML fragment in the editor.
-
-
-.. code-block:: xml
-
-          <field name="edmerpName"
-                 xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/
-                          gmd:pointOfContact[*/gmd:role/*/@codeListValue='edmerp']"
-                 del=".">
-
-          <text ref="edmerp-help"/>
-
-
-The fragment is defined in localization file strings.xml:
-
-.. code-block:: xml
-
-       <edmerp-help>
-         <div class="row">
-           <div class="col-xs-offset-2 col-xs-8">
-             <p class="help-block">The European Directory for Marine Environment
-                 Research Project (EDMERP) contains descriptions of many projects.
-                 This catalogue is maintained ...</p>
-             </div>
-         </div>
-       </edmerp-help>
-
-
-        Attributes:- **ref** (Mandatory)The tag name of the element to insert in the localization file.
-          - **if** (Optional)
-            
-An XPath expression to evaluate. If true, the text is displayed.
-          .. _creating-custom-editor-action:
-Adding a button
----------------
-
-A button which trigger an action (usually a process or a add button).
-
-Example of a button adding an extent:
-
-.. code-block:: xml
-
-        <action type="add"
-                name="extent"
-                or="extent"
-                in="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification">
-            <template>
-              <snippet>
-                <gmd:extent>
-                  <gmd:EX_Extent>
-                    <gmd:geographicElement>
-                      <gmd:EX_GeographicBoundingBox>
-                        <gmd:westBoundLongitude>
-                          <gco:Decimal/>
-                        </gmd:westBoundLongitude>
-                        <gmd:eastBoundLongitude>
-                          <gco:Decimal/>
-                        </gmd:eastBoundLongitude>
-                        <gmd:southBoundLatitude>
-                          <gco:Decimal/>
-                        </gmd:southBoundLatitude>
-                        <gmd:northBoundLatitude>
-                          <gco:Decimal/>
-                        </gmd:northBoundLatitude>
-                      </gmd:EX_GeographicBoundingBox>
-                    </gmd:geographicElement>
-                  </gmd:EX_Extent>
-                </gmd:extent>
-              </snippet>
-            </template>
-          </action>
-
-
-Example of a button displayed only if there is no resource identifier ending with
-the metadata record identifier (ie. ``if`` attribute) and running the process
-with ``add-resource-id`` identifier:
-
-.. code-block:: xml
-
-          <action type="process"
-                  process="add-resource-id"
-                  if="count(gmd:MD_Metadata/gmd:identificationInfo/*/
-                                gmd:citation/*/gmd:identifier[
-                                  ends-with(gmd:MD_Identifier/gmd:code/gco:CharacterString,
-                                            //gmd:MD_Metadata/gmd:fileIdentifier/gco:CharacterString)]) = 0"/>
-
-
-Example of a button based on custom directive with some directive attributes set by
-XPath:
-
-.. code-block:: xml
-
-          <action type="add"
-                  btnLabel="checkpoint-tdp-add-component"
-                  name="dataQualityInfo" or="dataQualityInfo"
-                  in="/mdb:MD_Metadata"
-                  addDirective="data-gn-record-fragment-selector">
-            <directiveAttributes data-source-records="xpath::string-join(
-              //mri:associatedResource/*[mri:initiativeType/*/@codeListValue = 'specification']
-                /mri:metadataReference/@uuidref, ',')"/>
-          </action>
-
-
-Example of a drowdown button with 3 coordinates system to choose from:
-
-.. code-block:: xml
-
-         <!-- Display CRS description only,
-                 customize label
-                 and drop the refSysInfo element if removed -->
-          <field xpath="/mdb:MD_Metadata/mdb:referenceSystemInfo/*/
-                           mrs:referenceSystemIdentifier/*/mcc:description"
-                 name="referenceSystemInfo"
-                 del="../../../.."/>
-
-          <!-- Add one of the 3 CRS proposed using the dropdown -->
-          <action type="add"
-                  btnLabel="addCrs"
-                  name="referenceSystemInfo" or="referenceSystemInfo"
-                  in="/mdb:MD_Metadata">
-            <template>
-              <snippet label="addCrs4326">
-                <mdb:referenceSystemInfo>
-                  <mrs:MD_ReferenceSystem>
-                    <mrs:referenceSystemIdentifier>
-                      <mcc:MD_Identifier>
-                        <mcc:code>
-                          <gco:CharacterString>http://www.opengis.net/def/crs/EPSG/0/4326</gco:CharacterString>
-                        </mcc:code>
-                        <mcc:description>
-                          <gco:CharacterString>WGS 84 (EPSG:4326)</gco:CharacterString>
-                        </mcc:description>
-                      </mcc:MD_Identifier>
-                    </mrs:referenceSystemIdentifier>
-                  </mrs:MD_ReferenceSystem>
-                </mdb:referenceSystemInfo>
-              </snippet>
-              <snippet label="addCrs4258">
-                <mdb:referenceSystemInfo>
-                  <mrs:MD_ReferenceSystem>
-                    <mrs:referenceSystemIdentifier>
-                      <mcc:MD_Identifier>
-                        <mcc:code>
-                          <gco:CharacterString>http://www.opengis.net/def/crs/EPSG/0/4258</gco:CharacterString>
-                        </mcc:code>
-                        <mcc:description>
-                          <gco:CharacterString>ETRS89 (EPSG:4258)</gco:CharacterString>
-                        </mcc:description>
-                      </mcc:MD_Identifier>
-                    </mrs:referenceSystemIdentifier>
-                  </mrs:MD_ReferenceSystem>
-                </mdb:referenceSystemInfo>
-              </snippet>
-              <snippet label="addCrs3035">
-                <mdb:referenceSystemInfo>
-                  <mrs:MD_ReferenceSystem>
-                    <mrs:referenceSystemIdentifier>
-                      <mcc:MD_Identifier>
-                        <mcc:code>
-                          <gco:CharacterString>http://www.opengis.net/def/crs/EPSG/0/3035</gco:CharacterString>
-                        </mcc:code>
-                        <mcc:description>
-                          <gco:CharacterString>ETRS89 / LAEA Europe (EPSG:3035)</gco:CharacterString>
-                        </mcc:description>
-                      </mcc:MD_Identifier>
-                    </mrs:referenceSystemIdentifier>
-                  </mrs:MD_ReferenceSystem>
-                </mdb:referenceSystemInfo>
-              </snippet>
-            </template>
-          </action>
-
-
-Example of a button to display a suggestion form:
-
-.. code-block:: xml
-
-          <action type="suggest"
-                  process="add-columns-from-csv"/>
-
-
-        Attributes:- **name** (Optional)TODO- **type** (Optional)The type of control- **process** (Optional)The process identifier (eg. add-resource-id) or the associated resource
-            type to open
-            (eg. onlinesrc, fcats, parent, source, sibling, service, dataset, thumbnail) See
-            onlinesrc directive.
-          - **forceLabel** (Optional)
-Force the label to be displayed for this action
-even if the action is not the first element of its
-kind. Label with always be displayed.
-
-          - **if** (Optional)
-            
-An XPath expression to evaluate. If true, the control is displayed. eg.
-
-
-.. code-block:: xml
-
-    count(gmd:MD_Metadata/gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation/
-    gmd:identifier[ends-with(gmd:MD_Identifier/gmd:code/gco:CharacterString,
-    //gmd:MD_Metadata/gmd:fileIdentifier/gco:CharacterString)]) = 0
-
-
-will only displayed the action control if the resource identifier does not end
-with the metadata identifier.
-          - **class** (Optional)Optional CSS class to add to the parent div element. eg. gn-required to show a *.- **btnLabel** (Optional)Optional label to be addded to the button.- **btnClass** (Optional)Optional CSS class to be added to the button.- **or** (Optional)Local name to match if the element does not exist.- **or** (Optional)
-            
-The local name of the geonet child (ie. non existing element) to match.
-
-.. code-block:: xml
-
-    <field xpath="/gmd:MD_Metadata/gmd:language"
-           or="language"
-           in="/gmd:MD_Metadata"/>
-
-- **or** (Optional)- **in** (Optional)XPath of the geonet:child element with the or name to look for. Usually
-        points to the parent of last element of the XPath attribute.
-      - **in** (Optional)The element to search in for the geonet child.- **addDirective** (Optional)The directive to use for the add control for this field.Child elements:- **template**, Optional element (see :ref:`creating-custom-editor-template`).. _creating-custom-editor-section:
-A group of field
-Attributes:- **name** (Mandatory)
-                  
-Section identifier.
-Translations are set on client side.
-                    
-                .. _creating-custom-editor-field:
-A field on which user can do batch editing.
-
-                  Attributes:- **name** (Mandatory)
-                        
-Field identifier.
-Translations are set on client side.
-                        
-                      - **xpath** (Mandatory)
-                        
-XPath of the element to edit.
-                        
-                      - **indexField** (Optional)
-                        
-Lucene index field name (as defined in dumpfields).
-The field will be used to preview current record values (TODO).
-                        
-                      - **use** (Optional)
-                        
-Field type. Register here any Angular directive to be used
-on the client side. Default is simple text field.
-                        
-                      - **removable** (Optional) Fixed value: **true**
-                        
-Define if the field could be marked as deleted.
-                        
-                      - **insertMode** (Optional)
-                        
-Define if the field should be insert or replace.
-Do not set this property for mandatory field (eg. title).
-                        
-                      - **codelist** (Optional)
-                        
-The codelist identifier. eg. gmd:MD_TopicCategoryCode for topic category.
-                        
-                      .. _creating-custom-editor-template:
-                          
-Define an XML template to use for the value to insert.
-                        
-                        
+.. _creating-custom-editor:Customizing editor##################.. _creating-custom-editor-editor:        A metadata editor configuration is defined for a specific schema plugin standard(see :ref:`implementing-a-schema-plugin`).The editor configuration defined the navigation menu (ie. list of views and tabs)for the editor, the list of fields and the type of control to use. Controls couldbe HTML type (eg. text, date) or more advanced control build using`AngularJS directive <https://docs.angularjs.org/guide/directive>`_.To build such an editor configuration user needs to know the XSD of the standardto properly build views, tabs and fields according to element names(see :code:`schemas/config-editor.xsd`). Create an editor root element andattach:- the schema and- namespaces for the standards.. code-block:: xml    <editor xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"      xsi:noNamespaceSchemaLocation="../../../../../../config-editor.xsd"      xmlns:gn="http://www.fao.org/geonetwork"      xmlns:gco="http://www.isotc211.org/2005/gco"      xmlns:gmd="http://www.isotc211.org/2005/gmd"      xmlns:gmx="http://www.isotc211.org/2005/gmx"      xmlns:srv="http://www.isotc211.org/2005/srv"      xmlns:gml="http://www.opengis.net/gml"      xmlns:xlink="http://www.w3.org/1999/xlink">An editor configuration should define first some general element description and thena set of views with at least one.        Child elements:- **fields**, Optional element (see :ref:`creating-custom-editor-fields`)- **fieldsWithFieldset**, Optional element (see :ref:`creating-custom-editor-fieldsWithFieldset`)- **multilingualFields**, Optional element (see :ref:`creating-custom-editor-multilingualFields`)- **views**, Mandatory element (see :ref:`creating-custom-editor-views`).. _creating-custom-editor-fields:Defining field type-------------------Define the form fields type configuration. Default is simple text input.This list contains the list of exception which does not use a simple text input.The list of possible values are:- all HTML5 input type or- an AngularJS directive name. MUST starts with 'data-' and  could end with '-textarea' to create a textarea element.  It could end with '-div' if the directive does not apply  to the input or textarea but to the div containing it.An element can only have one type defined... code-block:: xml    <editor>     <fields>       <for name="gmd:abstract" use="textarea"/>       <for name="gco:Real" use="number"/>       <for name="gco:Boolean" use="checkbox"/>       <for name="gco:Date" use="data-gn-date-picker"/>The other option to define a more advanced field type is to catch the element usingand XSL template. This approach is used for keywords in ISO19139 for example(see :code:`schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl`)... _creating-custom-editor-fieldsWithFieldset:Grouping element from the standards-----------------------------------List of element to be displayed in a fieldset (ie. boxed element). Thoseelements usually contain children elements and define major section in thestandard. For example, in ISO19139, identification and distribution are majorsection and should usually be displayed as a group of information... code-block:: xml    <editor>       <fields>...</fields>       <fieldsWithFieldset>        <name>gmd:identificationInfo</name>        <name>gmd:distributionInfo</name>        .. _creating-custom-editor-multilingualFields:Defining multilingual fields----------------------------Configure here the list of multilingual fields for a standard.By default, if the standard as multilingual support like ISO19139, all fields will be displayedas multilingual fields. Define in the exclude section the exception (eg. gmd:identifier for example in ISO19139).Then this section also allows to define how multilingual fields are displayed using the expanded elements.If expanded, then one field per language is displayed with no need to click on the language switcher... figure:: ../../user-guide/describing-information/img/multilingual-editing.png.. code-block:: xml    <editor>       <fields>...</fields>       <fieldsWithFieldset>...</fieldsWithFieldset>        <multilingualFields>          <expanded>            <name>gmd:title</name>            <name>gmd:abstract</name>          </expanded>          <exclude>            <name>gmd:identifier</name>            <name>gmd:metadataStandardName</name>        .. _creating-custom-editor-views:Configuring views-----------------At least one view MUST be defined but more view modes can be defined depending on the needs.By default ISO19139 define 3 views (ie. default, advanced, xml) and one disabled (ie. INSPIRE).See :code:`schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml` for the configuration... figure:: ../../user-guide/describing-information/img/view-mode.pngAnother basic example is the Dublin Core view (see :code:`schemas/dublin-core/src/main/plugin/dublin-core/layout/config-editor.xml`).To create a new view, use the following:.. code-block:: xml      <views>          <view name="viewNameInLocalizationFile">            ...          </view>              Child elements:- **view**, One or more (see :ref:`creating-custom-editor-view`).. _creating-custom-editor-view:Defining a view---------------A view has a label and define a specific rendering of the metadata records.A view is composed of one or more tabs... code-block:: xml      <views>          <view name="custom-view">              ....          </view>The view could be displayed or not according to the metadata record content orthe current user session using the displayIfRecord and displayIfServiceInfo attribute.              Attributes:- **name** (Mandatory)The key of the view name stored in ``{schema}/loc/{lang}/strings.xml`` or the element name with namespace prefix... code-block:: xml      <strings>        <default>Simple</default>        <inspire>INSPIRE</inspire>        <custom-view>My view</custom-view>            - **disabled** (Optional) Fixed value: **true**Hide the view from the menu if the attribute is defined. Allows to easily disable a view.            - **class** (Optional)Define custom CSS class to be set on the form element. This is mainly usedto set the type of indent: * gn-label-above-input: to put label above form input * gn-indent-colored: colored left border on each fieldset * gn-indent-bluescale: blue scale colored left border on each fieldsetSee catalog/views/default/less/gn_editor_default.less to add your custom editor styles.            - **upAndDownControlHidden** (Optional) Fixed value: **true**Define if up and down control should be displayed in that view. If not defined, controls are displayed.Hide those controls in a view to make it easier with less controls for the end-user... figure:: ../../user-guide/describing-information/img/editor-control-updown.png            - **displayAttributes** (Optional) Fixed value: **true**Display attributes by default when loading the view.- **displayTooltips** (Optional) Fixed value: **true**Display help documentation for all elements by default when loading the view.- **displayTooltipsMode** (Optional)Display help documentation onhover elements (default) or by clicking on an icon.- **hideTimeInCalendar** (Optional) Fixed value: **true**Define if calendar control should allows users to set date only ordatetime. If attribute is not set, then date and time can be set. This is controlled at the view level,switching to another view may allow more control over the dates.- **displayIfRecord** (Optional)XPath expression returning boolean value which will be evaluated against the metadata record. if true the view will be displayed.eg. Display custom-view if metadata standard name contains Medsea:.. code-block:: xml   <view name="custom-view"         displayIfRecord="contains(gmd:MD_Metadata/                                     gmd:metadataStandardName/gco:CharacterString,                                   'MedSea')"- **displayIfServiceInfo** (Optional)XPath expression returning boolean value which will be evaluate against the serviceinformation tree (Jeeves /root/gui element). if true the view will be displayed.eg. Display custom view if user is Administrator:.. code-block:: xml    <view name="custom-view"          displayIfServiceInfo="count(session[profile = 'Administrator']) = 1"displayIfRecord and displayIfServiceInfo could be combined. An AND operator is used. Both condition MUST returned true for the view to be displayed.Child elements:- **tab**, One or more (see :ref:`creating-custom-editor-tab`)- **flatModeExceptions**, Optional element (see :ref:`creating-custom-editor-flatModeExceptions`)- **thesaurusList**, Optional element (see :ref:`creating-custom-editor-thesaurusList`).. _creating-custom-editor-tab:Defining a tab--------------A view contains at least one tab. In that case it will be the default to display and notop toolbar will be displayed to switch from one tab to another... figure:: ../../user-guide/describing-information/img/editor-tab-switcher.pngAdd custom view one default tab and a field for the title:.. code-block:: xml      <views>        <view name="custom-view">          <tab id="custom-tab" default="true">            <section>              <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:title"/>            </section>          </tab>        </view>Attributes:- **id** (Mandatory)The tab key used in URL parameter to activate that tab. The key is also use for the tab label as defined in ``{schema}/loc/{lang}/strings.xml``.            - **default** (Optional) Fixed value: **true**Define if this tab is the default one for the view. Only one tab should be the default in a view.            - **toggle** (Optional) Fixed value: **true**Define if the tab should be displayed in a drop down menu instead of a tab. This is used for advancedsection which is not used often by the end-user. More than one tab could be grouped in that drop down tab menu.            - **formatter-order** (Optional)Define the ordering index of this tab in the XSLT formatter (Note used for editor).            - **mode** (Optional) Fixed value: **flat**The "flat" mode is an important concept to understand for the editor. It controls the way: - complex elements are displayed (ie. elements having children) and - non existing elements are displayed (ie. elements in the standard not in the current document).When a tab is in flat mode, this tab will not display element which are not in the current metadatadocument and it will display complex element as a group only if defined in the list ofelement with fieldset (see :ref:`creating-custom-editor-fieldsWithFieldset`).Example for a contact in non "flat" mode:.. figure:: ../../user-guide/describing-information/img/editor-contact-nonflatmode.pngExample for a contact in "flat" mode:.. figure:: ../../user-guide/describing-information/img/editor-contact-flatmode.pngThis mode makes the layout simpler but does not provide all controls to removesome of the usually boxed element. End-user can still move  to the advanced view modeto access those hidden elements in flat mode.It's recommended to preserve at least one view in non "flat" mode for reviewer or administrator in orderto be able: - to build proper templates based on the standards - to fix any types of errors.        - **mode** (Mandatory)- **displayIfRecord** (Optional)  XPath expression returning boolean value which will be evaluated against the metadata record. if true the view will be displayed.    eg. Display custom-view if metadata standard name contains Medsea:  .. code-block:: xml      <view name="custom-view"            displayIfRecord="contains(gmd:MD_Metadata/                                        gmd:metadataStandardName/gco:CharacterString,                                      'MedSea')"/>- **displayIfServiceInfo** (Optional)  XPath expression returning boolean value which will be evaluate against the service  information tree (Jeeves /root/gui element). if true the view will be displayed.  eg. Display custom view if user is Administrator:  .. code-block:: xml      <view name="custom-view"            displayIfServiceInfo="count(session[profile = 'Administrator']) = 1"To combine `displayIfRecord` and `displayIfServiceInfo` use an `AND` operator. In this case both condition MUST returned `true` for the view to be displayed... _creating-custom-editor-flatModeExceptions:Configuring complex element display~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~Elements to apply "flat" mode exceptions. By default,"flat" mode does not display elements containing only children and no value.Use or and in attribute to display non existing element.To display gmd:descriptiveKeywords element even if does not exist in the metadatarecord or if the field should be displayed to add new occurrences:.. code-block:: xml      <field            xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:descriptiveKeywords/*/gmd:keyword"            or="keyword"            in="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:descriptiveKeywords/*"/>   </tab>   <!-- Elements that should not use the "flat" mode -->   <flatModeExceptions>     <for name="gmd:descriptiveKeywords" />   </flatModeExceptions> </view>.. _creating-custom-editor-thesaurusList:Customizing thesaurus~~~~~~~~~~~~~~~~~~~~~To configure the type of transformationsor the number of keyword allowed or if the widgethas to be displayed in a fieldset or as simple field for ethesaurus define a specific configuration:eg. only 2 INSPIRE themes... code-block:: xml      <thesaurusList>        <thesaurus key="external.theme.httpinspireeceuropaeutheme-theme"                   maxtags="2"                   fieldset="false"                   transformations=""/>      </thesaurusList>      .. _creating-custom-editor-section:Adding a section to a tab-------------------------A section is a group of fields. If a name attribute is provided,then it will create an HTML fieldset which is collapsible.If no name attribute is provided, then it just render the inner elements.For example, if you need a tab without a root fieldset, juste create the mandatory section with no name and then the inner elements.        Attributes:- **name** (Optional)  An optional name to override the default one base on field name for the  section. The name must be defined in ``{schema}/loc/{lang}/strings.xml``.- **xpath** (Optional)  The xpath of the element to match. If an XPath is set for a section, it  should not contains any field.- **mode** (Optional) Fixed value: **flat**  The "flat" mode is an important concept to understand for the editor. It controls the way:  - complex elements are displayed (ie. elements having children) and  - non existing elements are displayed (ie. elements in the standard not in the current document).  When a tab is in flat mode, this tab will not display element which are not in the current metadata  document and it will display complex element as a group only if defined in the list of  element with fieldset (see :ref:`creating-custom-editor-fieldsWithFieldset`).  Example for a contact in non "flat" mode:  .. figure:: ../../user-guide/describing-information/img/editor-contact-nonflatmode.png          Contact in non "flat" mode  Example for a contact in "flat" mode:  .. figure:: ../../user-guide/describing-information/img/editor-contact-flatmode.png          Contact in "flat" mode  This mode makes the layout simpler but does not provide all controls to remove  some of the usually boxed element. End-user can still move  to the advanced view mode  to access those hidden elements in flat mode.  It's recommended to preserve at least one view in non "flat" mode for reviewer or administrator in order  to be able:  - to build proper templates based on the standards  - to fix any types of errors.- **mode** (Mandatory)- **or** (Optional)  Local name to match if the element does not exist.- **or** (Optional)  The local name of the geonet child (ie. non existing element) to match.  .. code-block:: xml      <field xpath="/gmd:MD_Metadata/gmd:language"             or="language"             in="/gmd:MD_Metadata"/>- **or** (Optional)- **in** (Optional)  XPath of the geonet:child element with the or name to look for. Usually  points to the parent of last element of the XPath attribute.- **in** (Optional)  The element to search in for the geonet child.- **displayIfRecord** (Optional)  XPath expression returning boolean value which will be evaluated against the metadata record. if true the view will be displayed.  eg. Display custom-view if metadata standard name contains Medsea:  .. code-block:: xml     <view name="custom-view"           displayIfRecord="contains(gmd:MD_Metadata/                                       gmd:metadataStandardName/gco:CharacterString,                                     'MedSea')">.. _creating-custom-editor-field:Adding a field--------------To display a simple element use the ``xpath`` attribute to point to the element to display:.. code-block:: xml      <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:title"/>To override a field label use the ``name`` attribute and define that new label in ``{schema}/loc/{lang}/strings.xml``:.. code-block:: xml      <field name="myTitle"             xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:title"/>To display a complex element which exist in the metadata document:.. code-block:: xml      <field name="pointOfContact"             xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:pointOfContact"/>In that case all children elements are also displayed.To display a field if exist in the metadata document or providing a add buttonin case it does not exist (specify ``in`` and ``or`` attribute):.. code-block:: xml      <field name="pointOfContact"             xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:pointOfContact"             or="pointOfContact"             in="/gmd:MD_Metadata/gmd:identificationInfo/*"             del="."/>Activate the "flat" mode at the tab level to make the form display only existing elements:.. code-block:: xml    <view name="custom-view">        <tab id="custom-tab" default="true" mode="flat">          <section>            <field                    xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:title"/>            <field name="pointOfContact"                   xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:pointOfContact"                   or="pointOfContact"                   in="/gmd:MD_Metadata/gmd:identificationInfo/*"                   del="."/>          </section>        </tab>      </view>        Attributes:- **xpath** (Mandatory)The xpath of the element to match.- **if** (Optional)An optional xpath expression to evaluate to define if the element should be displayedonly in some situation (eg. only for service metadata records). eg... code-block:: xml          <field            xpath="/gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/            gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:otherConstraints"            if="count(gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification) > 0"/>- **name** (Optional)A field name to override the default name.- **isMissingLabel** (Optional)The label to display if the element does not exist in the metadata record. It indicates thatthe element is missing in the current record. It could be use for a conformity section sayingthat the element is "not evaluated". EXPERIMENTAL                      - **or** (Optional)    The local name of the geonet child (ie. non existing element) to match.  .. code-block:: xml      <field xpath="/gmd:MD_Metadata/gmd:language"             or="language"             in="/gmd:MD_Metadata"/>- **in** (Optional)  The element to search in for the geonet child.- **del** (Optional)              Relative XPath of the element to remove when the remove button is clicked.  eg. If a template field match linkage and allows editing of field URL,  the remove control should remove the parent element gmd:onLine.  .. code-block:: xml      <field name="url"        xpath="/gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions                  /gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:linkage"        del="../..">        <template>  Del attribute can be used in template mode or not. Example to remove  spatialResolution while only editing denominator or distance. Denominator or distance  are mandatory but as the del element point to the spatialResolution  ancestor, there is no mandatory flag displayed and the remove control  remove the spatialResolution element.  .. code-block:: xml      <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/                      */gmd:spatialResolution/*/gmd:distance"             del="../.."/>      <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/                      */gmd:spatialResolution/                        */gmd:equivalentScale/*/gmd:denominator"             del="../../../.."/>- **templateModeOnly** (Optional) Fixed value: **true**  Define if the template mode should be the only mode used. In that case, the field is always  displayed based on the XML template snippet field configuration. Default is false.- **notDisplayedIfMissing** (Optional) Fixed value: **true**  If the field is found and a geonet child also, the geonet child to add a  new one is not displayed.- **use** (Optional)  The form field type to use (one of the HTML5 type) or an AngularJS directive to use.  This list is defined as an open enumeration. For directive, the value will be set in a simple  text input by default. If the directive needs to deal with cariage return character, the  directive name MUST contains "-textarea" in order to set the value in a textarea  instead of the text input.- **use** (Optional)  Field type. Register here any Angular directive to be used  on the client side. Default is simple text field.Child elements:- **template**, Optional element (see :ref:`creating-custom-editor-template`).. _creating-custom-editor-template:Adding a template based field-----------------------------A templace configuration for an XML snippet to edit.A template field is compose of an XML snippet corresponding to the element to edit where values to be edited are identified using {{fields}} notation. Each fields needs to be defined as values from which one input field will be created.This mode is used to hide the complexity of the XML element to edit. eg... code-block:: xml     <field name="url"            templateModeOnly="true"            xpath="/gmd:MD_Metadata/gmd:distributionInfo/g.../gmd:linkage">        <template>          <values>            <key label="url"                 xpath="gmd:URL"                 tooltip="gmd:linkage"/>          </values>          <snippet>t            <gmd:linkage>              <gmd:URL>{{url}}</gmd:URL>            </gmd:linkage>          </snippet>        </template>The template field mode will only provide editing of part of the snippet element. In some case the snippet may contains more elements than the one edited. In such case, the snippet MUST identified the list of potential elements in order to not to loose information when using this mode. Use the gn:copy element to properly combined the template with the current document.eg. The gmd:MD_Identifier may contain a gmd:authority node which needs to be preserved... code-block:: xml    <snippet>      <gmd:identifier>        <gmd:MD_Identifier>          <gn:copy select="gmd:authority"/>          <gmd:code>            <gco:CharacterString>{{code}}</gco:CharacterString>          </gmd:code>        </gmd:MD_Identifier>      </gmd:identifier>    </snippet>Warning: Template based field does not support multilingual editing for ISO standards (ie. only the main language is edited - therefore, multilingual elements will be preserved)... _creating-custom-editor-text:Adding documentation or help----------------------------Insert an HTML fragment in the editor... code-block:: xml          <field name="edmerpName"                 xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/                          gmd:pointOfContact[*/gmd:role/*/@codeListValue='edmerp']"                 del=".">          <text ref="edmerp-help"/>The fragment is defined in localization file strings.xml:.. code-block:: xml       <edmerp-help>         <div class="row">           <div class="col-xs-offset-2 col-xs-8">             <p class="help-block">The European Directory for Marine Environment                 Research Project (EDMERP) contains descriptions of many projects.                 This catalogue is maintained ...</p>             </div>         </div>       </edmerp-help>Attributes:- **ref** (Mandatory)The tag name of the element to insert in the localization file.- **if** (Optional)An XPath expression to evaluate. If true, the text is displayed... _creating-custom-editor-action:Adding a button---------------A button which trigger an action (usually a process or a add button).Example of a button adding an extent:.. code-block:: xml        <action type="add"                name="extent"                or="extent"                in="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification">            <template>              <snippet>                <gmd:extent>                  <gmd:EX_Extent>                    <gmd:geographicElement>                      <gmd:EX_GeographicBoundingBox>                        <gmd:westBoundLongitude>                          <gco:Decimal/>                        </gmd:westBoundLongitude>                        <gmd:eastBoundLongitude>                          <gco:Decimal/>                        </gmd:eastBoundLongitude>                        <gmd:southBoundLatitude>                          <gco:Decimal/>                        </gmd:southBoundLatitude>                        <gmd:northBoundLatitude>                          <gco:Decimal/>                        </gmd:northBoundLatitude>                      </gmd:EX_GeographicBoundingBox>                    </gmd:geographicElement>                  </gmd:EX_Extent>                </gmd:extent>              </snippet>            </template>          </action>Example of a button displayed only if there is no resource identifier ending withthe metadata record identifier (ie. ``if`` attribute) and running the processwith ``add-resource-id`` identifier:.. code-block:: xml          <action type="process"                  process="add-resource-id"                  if="count(gmd:MD_Metadata/gmd:identificationInfo/*/                                gmd:citation/*/gmd:identifier[                                  ends-with(gmd:MD_Identifier/gmd:code/gco:CharacterString,                                            //gmd:MD_Metadata/gmd:fileIdentifier/gco:CharacterString)]) = 0"/>Example of a button based on custom directive with some directive attributes set byXPath:.. code-block:: xml          <action type="add"                  btnLabel="checkpoint-tdp-add-component"                  name="dataQualityInfo" or="dataQualityInfo"                  in="/mdb:MD_Metadata"                  addDirective="data-gn-record-fragment-selector">            <directiveAttributes data-source-records="xpath::string-join(              //mri:associatedResource/*[mri:initiativeType/*/@codeListValue = 'specification']                /mri:metadataReference/@uuidref, ',')"/>          </action>Example of a drowdown button with 3 coordinates system to choose from:.. code-block:: xml         <!-- Display CRS description only,                 customize label                 and drop the refSysInfo element if removed -->          <field xpath="/mdb:MD_Metadata/mdb:referenceSystemInfo/*/                           mrs:referenceSystemIdentifier/*/mcc:description"                 name="referenceSystemInfo"                 del="../../../.."/>          <!-- Add one of the 3 CRS proposed using the dropdown -->          <action type="add"                  btnLabel="addCrs"                  name="referenceSystemInfo" or="referenceSystemInfo"                  in="/mdb:MD_Metadata">            <template>              <snippet label="addCrs4326">                <mdb:referenceSystemInfo>                  <mrs:MD_ReferenceSystem>                    <mrs:referenceSystemIdentifier>                      <mcc:MD_Identifier>                        <mcc:code>                          <gco:CharacterString>http://www.opengis.net/def/crs/EPSG/0/4326</gco:CharacterString>                        </mcc:code>                        <mcc:description>                          <gco:CharacterString>WGS 84 (EPSG:4326)</gco:CharacterString>                        </mcc:description>                      </mcc:MD_Identifier>                    </mrs:referenceSystemIdentifier>                  </mrs:MD_ReferenceSystem>                </mdb:referenceSystemInfo>              </snippet>              <snippet label="addCrs4258">                <mdb:referenceSystemInfo>                  <mrs:MD_ReferenceSystem>                    <mrs:referenceSystemIdentifier>                      <mcc:MD_Identifier>                        <mcc:code>                          <gco:CharacterString>http://www.opengis.net/def/crs/EPSG/0/4258</gco:CharacterString>                        </mcc:code>                        <mcc:description>                          <gco:CharacterString>ETRS89 (EPSG:4258)</gco:CharacterString>                        </mcc:description>                      </mcc:MD_Identifier>                    </mrs:referenceSystemIdentifier>                  </mrs:MD_ReferenceSystem>                </mdb:referenceSystemInfo>              </snippet>              <snippet label="addCrs3035">                <mdb:referenceSystemInfo>                  <mrs:MD_ReferenceSystem>                    <mrs:referenceSystemIdentifier>                      <mcc:MD_Identifier>                        <mcc:code>                          <gco:CharacterString>http://www.opengis.net/def/crs/EPSG/0/3035</gco:CharacterString>                        </mcc:code>                        <mcc:description>                          <gco:CharacterString>ETRS89 / LAEA Europe (EPSG:3035)</gco:CharacterString>                        </mcc:description>                      </mcc:MD_Identifier>                    </mrs:referenceSystemIdentifier>                  </mrs:MD_ReferenceSystem>                </mdb:referenceSystemInfo>              </snippet>            </template>          </action>Example of a button to display a suggestion form:.. code-block:: xml          <action type="suggest"                  process="add-columns-from-csv"/>        Attributes:- **name** (Optional)  TODO- **type** (Optional)  The type of control- **process** (Optional)  The process identifier (eg. add-resource-id) or the associated resource type to open  (eg. onlinesrc, fcats, parent, source, sibling, service, dataset, thumbnail) See  onlinesrc directive.          - **forceLabel** (Optional)  Force the label to be displayed for this action  even if the action is not the first element of its  kind. Label with always be displayed.          - **if** (Optional)  An XPath expression to evaluate. If true, the control is displayed. eg.  .. code-block:: xml      count(gmd:MD_Metadata/gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation/      gmd:identifier[ends-with(gmd:MD_Identifier/gmd:code/gco:CharacterString,      //gmd:MD_Metadata/gmd:fileIdentifier/gco:CharacterString)]) = 0  will only displayed the action control if the resource identifier does not end  with the metadata identifier.        - **class** (Optional)  Optional CSS class to add to the parent div element. eg. gn-required to show a `*`.- **btnLabel** (Optional)  Optional label to be addded to the button.- **btnClass** (Optional)  Optional CSS class to be added to the button.- **or** (Optional)  Local name to match if the element does not exist.- **or** (Optional)              The local name of the geonet child (ie. non existing element) to match.  .. code-block:: xml      <field xpath="/gmd:MD_Metadata/gmd:language"             or="language"             in="/gmd:MD_Metadata"/>- **or** (Optional)- **in** (Optional)  XPath of the geonet:child element with the or name to look for. Usually  points to the parent of last element of the XPath attribute.- **in** (Optional)  The element to search in for the geonet child.- **addDirective** (Optional)  The directive to use for the add control for this field.Child elements:- **template**, Optional element (see :ref:`creating-custom-editor-template`).. _creating-custom-editor-group:Adding a group--------------A group of fieldAttributes:- **name** (Mandatory)    Section identifier.  Translations are set on client side.A field on which user can do batch editing.Attributes:- **name** (Mandatory)    Field identifier.  Translations are set on client side.- **xpath** (Mandatory)                          XPath of the element to edit.- **indexField** (Optional)  Lucene index field name (as defined in dumpfields).  The field will be used to preview current record values (TODO).- **use** (Optional)  Field type. Register here any Angular directive to be used  on the client side. Default is simple text field.                                              - **removable** (Optional) Fixed value: **true**                          Define if the field could be marked as deleted.- **insertMode** (Optional)  Define if the field should be insert or replace.  Do not set this property for mandatory field (eg. title).- **codelist** (Optional)  The codelist identifier. eg. gmd:MD_TopicCategoryCode for topic category.- **template**   Define an XML template to use for the value to insert.

--- a/source/maintainer-guide/installing/installing-from-source-code.rst
+++ b/source/maintainer-guide/installing/installing-from-source-code.rst
@@ -6,21 +6,36 @@ Installing from source code
 System Requirements
 ===================
 
+Java 8
+------
 
 GeoNetwork is a Java 8 application that runs as a servlet so the Java Development Kit
 (JDK) must be installed in order to build and run it.
-You can get a Java 8 JDK from your Linux distribution, [Oracle OpenJDK](http://openjdk.java.net/) or [AdoptOpenJDK](https://adoptopenjdk.net). Please keep in mind that [Oracle JDK](http://www.oracle.com/technetwork/java/javase/downloads) Java 8 is no longer distributed for development, only testing purposes.
+You can get a Java 8 JDK from your Linux distribution, `Oracle OpenJDK <http://openjdk.java.net/>`__ or `AdoptOpenJDK <https://adoptopenjdk.net>`__. Please keep in mind that `Oracle JDK <http://www.oracle.com/technetwork/java/javase/downloads>`__ Java 8 is no longer distributed for development, only testing purposes.
 
-GeoNetwork is developed with Java 8. GeoNetwork should not be developed with newer versions, and won’t run at all with Java 7, 1.6 or earlier releases.
+GeoNetwork is developed with Java 8 (LTS):
 
-Being written in Java, GeoNetwork can run on any platform that supports Java, so it can run on Windows, Linux and Mac OSX.
+* GeoNetwork should not be developed with newer versions of Java
+* Java 11 (LTS) is not supported at this time
+* GeoNetwork won’t run at all with Java 7, 1.6 or earlier releases.
 
-Next, you need a servlet container. GeoNetwork comes with an embedded container ([Eclipse Jetty](https://www.eclipse.org/jetty/))
-which is fast and well suited for most applications. If you need a stronger one, you
-can install Tomcat from the Apache Software Foundation (http://tomcat.apache.org).
-It provides load balancing, fault tolerance and other production features. If you
-work for an organisation, it is probable that you already use Tomcat.
-The tested version is 8.x.
+Application Sever
+-----------------
+
+Next, you need a servlet container. GeoNetwork comes with an embedded container `Eclipse Jetty <https://www.eclipse.org/jetty/>`__
+which is fast and well suited for most applications.
+
+If you need a stronger one, we recommend `Apache Tomact <http://tomcat.apache.org>`__.
+Tomcat provides load balancing, fault tolerance and other production features. Apache Tomcat
+is widely used with many organizations standardizing on Tomcat for all their Java Web Applications.
+
+We recommend the stable releases of tomcat:
+
+* Apache Tomcat 8.5
+* Apache Tomcat 9.0
+
+Database
+--------
 
 Regarding storage, you need a Database Management System (DBMS) like Oracle,
 MySQL, Postgresql etc. GeoNetwork comes with an embedded DBMS (H2) which is
@@ -29,16 +44,26 @@ installations of no more than a few thousand metadata records with one or
 two users. If you have heavier demands then you should use a professional, stand
 alone DBMS.
 
+Environment
+-----------
+
+Being written in Java, GeoNetwork can run on any platform that supports Java: primarily Linux, Windows and macOS.
+
 GeoNetwork is not resource intensive and will not require a powerful machine. Good performance can be
-obtained with 1GB of RAM. The suggested amount is 2GB of RAM. For hard disk
-space, you have to consider the space required for the application itself
+obtained with 1GB of RAM. The suggested amount is 2GB of RAM.
+
+For hard disk space, you have to consider the space required for the application itself
 (about 350 MB) and the space required for data, which can require 50 GB or
 more. A simple disk of 250 GB should be OK.  You also need some disk space
-for the search index which is located in ``GEONETWORK_DATA_DIR/index`` (by default GEONETWORK_DATA_DIR is ``INSTALL_DIR/web/geonetwork/WEB_INF/data``. However, even with a few thousand metadata records, the index is small so usually 500 MB of space is more than enough.
+for the search index which is located in ``GEONETWORK_DATA_DIR/index``
+(by default GEONETWORK_DATA_DIR is ``INSTALL_DIR/web/geonetwork/WEB_INF/data``).
+However, even with a few thousand metadata records, the index is small so usually
+500 MB of space is more than enough.
 
 The software is run in different ways depending on the servlet container you are using:
 
 * *Tomcat* - GeoNetwork is available as a WAR file which you can put into the Tomcat webapps directory. Tomcat will deploy the WAR file when it is started. You can then use the Tomcat manager web application to stop/start GeoNetwork. You can also use the startup.* and shutdown.* scripts located in the Tomcat bin directory (.* means .sh or .bat depending on your OS) but if you have other web applications in the tomcat container, then they will also be affected.
+
 * *Jetty* - If you use the provided container you can use the scripts in GeoNetwork’s bin directory. The scripts are startup.* and shutdown.* and you must be inside the bin directory to run them. You can use these scripts just after installation.
 
 Tools
@@ -46,7 +71,7 @@ Tools
 
 The following tools are required to be installed to setup a development environment for GeoNetwork:
 
-* **Java** - Developing with GeoNetwork requires Java Development Kit (JDK) 1.8.
+* **Java 8** - Developing with GeoNetwork requires Java Development Kit (JDK) 1.8.
 * **Maven** 3.1.0+ - GeoNetwork uses [Maven](http://maven.apache.org/) to manage the build process and the dependencies. Once is installed, you should have the mvn command in your path (on Windows systems, you have to open a shell to check).
 * **Git** - GeoNetwork source code is stored and versioned in [a Git repository on Github](https://github.com/geonetwork/core-geonetwork). Depending on your operating system a variety of git clients are avalaible. Check in http://git-scm.com/downloads/guis for some alternatives.  Good documentation can be found on the git website: http://git-scm.com/documentation and on the Github website https://help.github.com/.
 * **Ant** - GeoNetwork uses [Ant](http://ant.apache.org/) to build the installer.  Version 1.6.5 works but any other recent version should be OK. Once installed, you should have the ant command in your path (on Windows systems, you have to open a shell to check).
@@ -55,7 +80,6 @@ The following tools are required to be installed to setup a development environm
 
 The quick way
 =============
-
 
 Get GeoNetwork running - the short path
 

--- a/source/maintainer-guide/production-use/index.rst
+++ b/source/maintainer-guide/production-use/index.rst
@@ -35,7 +35,7 @@ A common challenge in production use is the fact that java only has a limited se
 Data folder
 -----------
 
-GeoNetwork requires a data folder to store objects uploaded by administrators and managers and some configuration options. By default this folder is located in :file:`/geonetwork/WEB-INF/data`. In production situation configure the location of this folder outside the application and make sure the folder is backed up. You can use an environment variable to configure the location of the data folder. Read more at :ref:`customizing-the-data-directory`
+GeoNetwork requires a data folder to store objects uploaded by administrators and managers and some configuration options. By default this folder is located in :file:`/geonetwork/WEB-INF/data`. In production situation configure the location of this folder outside the application and make sure the folder is backed up. You can use an environment variable to configure the location of the data folder. Read more at :ref:`customizing-data-directory`
 
 Memory
 ------

--- a/source/maintainer-guide/statistics/index.rst
+++ b/source/maintainer-guide/statistics/index.rst
@@ -10,9 +10,7 @@ This guide describes the configuration required to integrate ElasticSearch/Kiban
 
 GeoNetwork 3.8.x supports ElasticSearch/Kibana 7.2, other versions may not work properly.
 
-.. note::
-
-   This guide doesn't provide a production level setup for ElasticSearch/Kibana. Please refer to the ElasticSearch/Kibana documentation to do a proper setup/configuration for a production environment.
+.. note::  This guide doesn't provide a production level setup for ElasticSearch/Kibana. Please refer to the ElasticSearch/Kibana documentation to do a proper setup/configuration for a production environment.
 
 .. toctree::
    :maxdepth: 2

--- a/source/maintainer-guide/statistics/setup-elasticsearch.rst
+++ b/source/maintainer-guide/statistics/setup-elasticsearch.rst
@@ -10,9 +10,7 @@ Installation
 
 ElasticSearch can be installed manually, or for some operating systems packages are available. 
 
-.. note::
-
-....If installed manually, ElasticSearch must be configured as a service to ensure it starts automatically when the server is started. This is beyond the scope of this guide.
+.. note::  If installed manually, ElasticSearch must be configured as a service to ensure it starts automatically when the server is started. This is beyond the scope of this guide.
 
 To install manually:
 

--- a/source/overview/change-log/version-3.8.0.rst
+++ b/source/overview/change-log/version-3.8.0.rst
@@ -8,61 +8,65 @@ New features/fixes
 
 * Search experience
 
- * `Saved searches <https://github.com/geonetwork/core-geonetwork/pull/3778>`_
+  * `Saved searches <https://github.com/geonetwork/core-geonetwork/pull/3778>`_
 
-.. figure:: img/380-usersearches.png
-
-
- * `Improve PDF output <https://github.com/geonetwork/core-geonetwork/pull/3912>`_
-
- * `Add template to display related record as list <https://github.com/geonetwork/core-geonetwork/pull/3908>`_
+    .. figure:: img/380-usersearches.png
+       
+       Saved user searches
 
 
-.. figure:: img/380-related.png
+  * `Improve PDF output <https://github.com/geonetwork/core-geonetwork/pull/3912>`_
+
+  * `Add template to display related record as list <https://github.com/geonetwork/core-geonetwork/pull/3908>`_
 
 
- * `Add support for negative query on any fields <https://github.com/geonetwork/core-geonetwork/pull/3683>`_
+     .. figure:: img/380-related.png
+        
+        Add template
+
+  * `Add support for negative query on any fields <https://github.com/geonetwork/core-geonetwork/pull/3683>`_
 
 * Standards
 
- * `ISO19115-3:2018 is now a default standard <https://github.com/metadata101/iso19115-3.2018>`_
+  * `ISO19115-3:2018 is now a default standard <https://github.com/metadata101/iso19115-3.2018>`_
 
- * `ISO19139 / JSON-LD formatter <https://github.com/geonetwork/core-geonetwork/pull/3714>`_
+  * `ISO19139 / JSON-LD formatter <https://github.com/geonetwork/core-geonetwork/pull/3714>`_
 
- * `ISO19139:2007 / Update schema <https://github.com/geonetwork/core-geonetwork/pull/3920>`_
+  * `ISO19139:2007 / Update schema <https://github.com/geonetwork/core-geonetwork/pull/3920>`_
 
- * INSPIRE Technical guidance v2 support
+  * INSPIRE Technical guidance v2 support
 
-  * Add support for `etf-webapp validation with TG2 for datasets and sds <https://github.com/geonetwork/core-geonetwork/pull/3915>`_ and also `support validating non ISO19139 records like ISO19115-3 <https://github.com/geonetwork/core-geonetwork/pull/3766>`_
+    * Add support for `etf-webapp validation with TG2 for datasets and sds <https://github.com/geonetwork/core-geonetwork/pull/3915>`_ and also `support validating non ISO19139 records like ISO19115-3 <https://github.com/geonetwork/core-geonetwork/pull/3766>`_
 
-  * `Improve support for gmx:Anchor encoding <https://github.com/geonetwork/core-geonetwork/pull/3911>`_
+    * `Improve support for gmx:Anchor encoding <https://github.com/geonetwork/core-geonetwork/pull/3911>`_
 
- * `ISO19110 / Populate columns and codelist values from CSV <https://github.com/geonetwork/core-geonetwork/pull/3864>`_
-
+  * `ISO19110 / Populate columns and codelist values from CSV <https://github.com/geonetwork/core-geonetwork/pull/3864>`_
 
 * Editor
 
- * `Working copy support for approved records <https://github.com/geonetwork/core-geonetwork/pull/3592>`_
+  * `Working copy support for approved records <https://github.com/geonetwork/core-geonetwork/pull/3592>`_
 
- * `Associated resource can now be filtered, sorted <https://github.com/geonetwork/core-geonetwork/pull/3804>`_, add `support for WFS and Atom services <https://github.com/geonetwork/core-geonetwork/pull/3817>`_.
+  * `Associated resource can now be filtered, sorted <https://github.com/geonetwork/core-geonetwork/pull/3804>`_, add `support for WFS and Atom services <https://github.com/geonetwork/core-geonetwork/pull/3817>`_.
 
-.. figure:: img/380-associated.png
+     .. figure:: img/380-associated.png
+       
+        Filtering associated resources
 
 * Harvester
 
- * `GeoNetwork / Add paging for better support of large catalogues <https://github.com/geonetwork/core-geonetwork/pull/3916>`_
+  * `GeoNetwork / Add paging for better support of large catalogues <https://github.com/geonetwork/core-geonetwork/pull/3916>`_
 
- * `THREDDS / Modernise and simplify harvester <https://github.com/geonetwork/core-geonetwork/pull/3936>`_
+  * `THREDDS / Modernise and simplify harvester <https://github.com/geonetwork/core-geonetwork/pull/3936>`_
 
- * `WFS feature / Zoom to results <https://github.com/geonetwork/core-geonetwork/pull/3701>`_, add support for CDATA, Update to Elasticsearch 7.2.
+  * `WFS feature / Zoom to results <https://github.com/geonetwork/core-geonetwork/pull/3701>`_, add support for CDATA, Update to Elasticsearch 7.2.
 
 
 * Administration
 
- * New user interface settings for: humanizing date, enable user searches, enable saved selections, fluid or not container
+  * New user interface settings for: humanizing date, enable user searches, enable saved selections, fluid or not container
 
 * Security fixes and library updates
 
 
-and more ... see `3.8.0 issues <https://github.com/geonetwork/core-geonetwork/issues?q=is%3Aissue+milestone%3A3.8.0+is%3Aclosed>`_ and
+And more ... see `3.8.0 issues <https://github.com/geonetwork/core-geonetwork/issues?q=is%3Aissue+milestone%3A3.8.0+is%3Aclosed>`_ and
 `pull requests <https://github.com/geonetwork/core-geonetwork/pulls?q=milestone%3A3.8.0+is%3Aclosed+is%3Apr>`_ for full details.

--- a/source/tutorials/hookcustomizations/events/index.rst
+++ b/source/tutorials/hookcustomizations/events/index.rst
@@ -8,43 +8,43 @@ From GeoNetwork 3.0.x on, there are a number of events you can listen to on your
 Enabling Event Listeners
 ========================
 
-To enable this on your Maven project, you have to add the event dependencies. Edit the file custom/pom.xml and add the dependencies tag:
+To enable this on your Maven project, you have to add the event dependencies. Edit the file :file:`custom/pom.xml` and add the dependencies tag:
 
 
-  ::
+.. code:: xml
 
-  <dependencies>
-  <dependency>
-  <groupId>${project.groupId}</groupId>
-  <artifactId>events</artifactId>
-  <version>${project.version}</version>
-  </dependency>
-  <dependency>
-  <groupId>${project.groupId}</groupId>
-  <artifactId>core</artifactId>
-  <version>${project.version}</version>
-  </dependency>
-  </dependencies>
+   <dependencies>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>events</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+   </dependencies>
 
 
 Then create the file custom/src/main/resources/config-spring-geonetwork.xml to tell Spring to load your custom beans adding the following content:
 
-  .. code::
+.. code:: xml
 
-  <?xml version="1.0" encoding="UTF-8"?>
-  <beans xmlns="http://www.springframework.org/schema/beans"
-  xmlns:util="http://www.springframework.org/schema/util"
-  xmlns:context="http://www.springframework.org/schema/context"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="
-  http://www.springframework.org/schema/beans 
-  http://www.springframework.org/schema/beans/spring-beans.xsd
-  http://www.springframework.org/schema/util
-  http://www.springframework.org/schema/util/spring-util.xsd
-  http://www.springframework.org/schema/context
-  http://www.springframework.org/schema/context/spring-context-3.2.xsd" >
-  <bean class="org.fao.geonet.events.listeners.MyCustomListener" ></bean>
-  </beans>
+     <?xml version="1.0" encoding="UTF-8"?>
+     <beans xmlns="http://www.springframework.org/schema/beans"
+            xmlns:util="http://www.springframework.org/schema/util"
+            xmlns:context="http://www.springframework.org/schema/context"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation=
+               "http://www.springframework.org/schema/beans 
+                http://www.springframework.org/schema/beans/spring-beans.xsd
+                http://www.springframework.org/schema/util
+                http://www.springframework.org/schema/util/spring-util.xsd
+                http://www.springframework.org/schema/context
+                http://www.springframework.org/schema/context/spring-context-3.2.xsd">
+       <bean class="org.fao.geonet.events.listeners.MyCustomListener" ></bean>
+     </beans>
 
 This file should contain a list of all the classes that listen to events inside GeoNetwork scope.
 
@@ -53,25 +53,25 @@ Simple Example
 
 We can add a simple example listener like this one, which will print a string every time a metadata gets removed.
 
-  .. code::java
+.. code::java
 
-  package org.fao.geonet.events.listeners;
+   package org.fao.geonet.events.listeners;
 
-  import org.fao.geonet.domain.*;
+   import org.fao.geonet.domain.*;
 
-  import org.fao.geonet.events.md.MetadataRemove;
+   import org.fao.geonet.events.md.MetadataRemove;
 
-  import org.springframework.context.ApplicationListener;
+   import org.springframework.context.ApplicationListener;
 
-  import org.springframework.stereotype.Component;
+   import org.springframework.stereotype.Component;
 
-  @Component
-  public class MyCustomListener implements ApplicationListener<MetadataRemove> { 
-     @Override
-     public void onApplicationEvent(MetadataRemove event) {
- 	System.out.println("REMOVED");
-     }
-  }
+   @Component
+   public class MyCustomListener implements ApplicationListener<MetadataRemove> { 
+      @Override
+      public void onApplicationEvent(MetadataRemove event) {
+         System.out.println("REMOVED");
+      }
+   }
 
 
 For example, we can call an external REST API that gets triggered every time a Metadata gets removed or updated.

--- a/source/tutorials/hookcustomizations/newproject/index.rst
+++ b/source/tutorials/hookcustomizations/newproject/index.rst
@@ -24,89 +24,89 @@ To do this, go to the root folder of the source code and create a new folder. Th
 Then we have to tell Maven this is a new project that can be built. So we add a new file called pom.xml on this "custom" folder and add the following:
 
 
-::
+.. code::xml
 
- <project xmlns="http://maven.apache.org/POM/4.0.0"
-   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+   <project xmlns="http://maven.apache.org/POM/4.0.0"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
  
-   <modelVersion>4.0.0</modelVersion>
+     <modelVersion>4.0.0</modelVersion>
  
-   <parent>
+     <parent>
+       <groupId>org.geonetwork-opensource</groupId>
+       <artifactId>geonetwork</artifactId>
+       <version>3.1.0-SNAPSHOT</version>
+     </parent>
+ 
      <groupId>org.geonetwork-opensource</groupId>
-     <artifactId>geonetwork</artifactId>
-     <version>3.1.0-SNAPSHOT</version>
-   </parent>
+     <artifactId>custom</artifactId>
+     <packaging>jar</packaging>
+     <name>Hook your customizations tutorial</name>
+     <description/>
  
-   <groupId>org.geonetwork-opensource</groupId>
-   <artifactId>custom</artifactId>
-   <packaging>jar</packaging>
-   <name>Hook your customizations tutorial</name>
-   <description/>
+     <licenses>
+       <license>
+         <name>General Public License (GPL)</name>
+         <url>http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</url>
+         <distribution>repo</distribution>
+       </license>
+     </licenses>
  
-   <licenses>
-     <license>
-       <name>General Public License (GPL)</name>
-       <url>http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</url>
-       <distribution>repo</distribution>
-     </license>
-   </licenses>
- 
-   <properties>
-     <geonetwork.build.dir>${project.build.directory}/${project.build.finalName}</geonetwork.build.dir>
-     <closure.compile.level/>
-   </properties>
-     <profiles>
-         <profile>
-             <id>tests-and-static-analysis</id>
-             <activation>
-                 <property><name>!skipTests</name></property>
-             </activation>
-         </profile>
-     </profiles>
- </project>
+     <properties>
+       <geonetwork.build.dir>${project.build.directory}/${project.build.finalName}</geonetwork.build.dir>
+       <closure.compile.level/>
+     </properties>
+       <profiles>
+           <profile>
+               <id>tests-and-static-analysis</id>
+               <activation>
+                   <property><name>!skipTests</name></property>
+               </activation>
+           </profile>
+       </profiles>
+   </project>
 
 Add your project
 ================
 
 Then you should add it to the list of projects maven will automatically build. On the root folder of the source code, edit the file pom.xml and add your own project:
 
- ::
+.. code:: xml
 
- <modules>
- <module>schemas-test</module>		          
- <module>web-ui</module>
- <module>custom</module>		          
- <module>web-ui-docs</module>		          
- <module>web-client</module>		          
- <module>web</module>
- </modules>
+   <modules>
+     <module>schemas-test</module>		          
+     <module>web-ui</module>
+     <module>custom</module>		          
+     <module>web-ui-docs</module>		          
+     <module>web-client</module>		          
+     <module>web</module>
+   </modules>
 
 The idea is that not only we build the project, but also add it to the war file that is being generated. To do this, we edit the file web/pom.xml and add our project as a new dependency inside the tag dependencies:
 
- ::
+.. code:: xml
 
- <dependency>
- <groupId>${project.groupId}</groupId>
- <artifactId>custom</artifactId>
- <version>${project.version}</version>
- </dependency>
+   <dependency>
+     <groupId>${project.groupId}</groupId>
+     <artifactId>custom</artifactId>
+     <version>${project.version}</version>
+   </dependency>
 
 And on the same file, we should also add our resources folder to the build (if we are going to modify the UI, which we will on this tutorial):
 
- ::
+.. code:: xml
 
- <resource>
- <directory>${project.basedir}/../custom/src/main/resources</directory>
- </resource>
+   <resource>
+     <directory>${project.basedir}/../custom/src/main/resources</directory>
+   </resource>
 
-  ::
+.. code:: xml
 
-  <resourcesAsCSV>
-  ${project.basedir}/src/main/webapp,
-  ${rootProjectDir}/web-ui/src/main/resources/,	
-  ${rootProjectDir}/custom/src/main/resources/,
-  ${build.webapp.resources}
-  </resourcesAsCSV>
+   <resourcesAsCSV>
+   ${project.basedir}/src/main/webapp,
+   ${rootProjectDir}/web-ui/src/main/resources/,	
+   ${rootProjectDir}/custom/src/main/resources/,
+   ${build.webapp.resources}
+   </resourcesAsCSV>
 
 Now, if we build GeoNetwork, it will also build and add our project.

--- a/source/tutorials/hookcustomizations/ui/index.rst
+++ b/source/tutorials/hookcustomizations/ui/index.rst
@@ -16,34 +16,34 @@ We  need an empty file on the custom/src/main/resources/catalog/views/custom/les
 
 Then we need to define the basic Angular module that will be used on this style. Create a file on custom/src/main/resources/catalog/views/custom/module.js and add the following content:
 
-  .. code::javascript
+.. code:: javascript
 
- (function() {
- goog.provide('gn_search_custom');
- goog.require('gn_search');
- var module = angular.module('gn_search_custom', ['gn_search']);
- })();
+   (  function() {
+        goog.provide('gn_search_custom');
+        goog.require('gn_search');
+        var module = angular.module('gn_search_custom', ['gn_search']);
+   })();
 
 Next we create a new file on custom/src/main/resources/catalog/views/custom/templates/index.html and add the following content:
 
- ::
+.. code:: html
 
- <div>This is my custom GeoNetwork</div>
+   <div>This is my custom GeoNetwork</div>
 
 Finally we have to tell the wro4j library where our files will be. Edit the file web-ui/src/main/resources/WEB-INF/classes/web-ui-wro-sources.xml and add our folders:
 
- ::
+.. code:: xml
 
- <require pathOnDisk="web-ui/src/main/resources" >
- <jsSource webappPath="/catalog/js/" />
- <jsSource webappPath="/catalog/views/default/" />
- <jsSource webappPath="/catalog/views/custom/" />
- <jsSource webappPath="/catalog/components/" />
- <cssSource webappPath="/catalog/views/default/" />
- <cssSource webappPath="/catalog/views/custom/" />
- <cssSource webappPath="/catalog/style/" />
- <cssSource webappPath="/catalog/lib/bootstrap-table/dist" />
- </require>
+   <require pathOnDisk="web-ui/src/main/resources" >
+     <jsSource webappPath="/catalog/js/" />
+     <jsSource webappPath="/catalog/views/default/" />
+     <jsSource webappPath="/catalog/views/custom/" />
+     <jsSource webappPath="/catalog/components/" />
+     <cssSource webappPath="/catalog/views/default/" />
+     <cssSource webappPath="/catalog/views/custom/" />
+     <cssSource webappPath="/catalog/style/" />
+     <cssSource webappPath="/catalog/lib/bootstrap-table/dist" />
+   </require>
 
 Now, if we build, deploy and enter GeoNetwork, we can use this new style called "custom": http://localhost:8080/geonetwork/srv/eng/catalog.search?view=custom
 
@@ -54,19 +54,19 @@ You can import the default style to have an easy start on your new style.
 
 Edit custom/src/main/resources/catalog/views/custom/less/gn_search_custom.less and add the following line:
 
-  .. code::javascript
+.. code:: less
 
-  @import "gn_search_default.css";
+   @import "gn_search_default.css";
 
 Then make the Angular module dependant of the default Angular UI module. Edit custom/src/main/resources/catalog/views/custom/module.js and replace the contents with:
 
-  .. code::javascript
+.. code:: javascript
 
- (function() {
- goog.provide('gn_search_custom');
- goog.require('gn_search_default');
- var module = angular.module('gn_search_custom', ['gn_search_default']);
- })();
+   (  function() {
+         goog.provide('gn_search_custom');
+         goog.require('gn_search_default');
+         var module = angular.module('gn_search_custom', ['gn_search_default']);
+   })();
 
 
 Finally, replace the file custom/src/main/resources/catalog/views/custom/templates/index.html with the contents of the file web-ui/src/main/resources/catalog/views/default/templates/index.html
@@ -80,42 +80,42 @@ Modify Search Results
 
 One of the most common customizations on the styling of GeoNetwork is to modify the appearance of the search result list. We can point to a different template on the config.js file. Edit the file custom/src/main/resources/catalog/views/custom/config.js and modify the property searchSettings.resultViewTpls.
 
-  .. code::javascript
+.. code:: javascript
 
-  searchSettings.resultViewTpls = [{
-                  tplUrl: '../../catalog/views/custom/resultsview/' +
-                  'partials/viewtemplates/grid.html',
-                  tooltip: 'Grid',
-                  icon: 'fa-th'
-                }];
-
+   searchSettings.resultViewTpls = [{
+                   tplUrl: '../../catalog/views/custom/resultsview/' +
+                   'partials/viewtemplates/grid.html',
+                   tooltip: 'Grid',
+                   icon: 'fa-th'
+                 }];
 
 And now we have to create the referenced file web-ui/src/main/resources/catalog/views/custom/resultsview/partials/viewtemplates/grid.html and use the template we want, like:
 
-  .. code::javascript
-  <ul class="list-group gn-resultview gn-resultview-sumup">
-    <li class="list-group-item gn-grid"
-      data-ng-repeat="md in searchResults.records"
-      data-gn-fix-mdlinks=""
-      data-gn-displayextent-onhover=""
-      data-gn-zoomto-onclick="">
+.. code:: html
+  
+   <ul class="list-group gn-resultview gn-resultview-sumup">
+     <li class="list-group-item gn-grid"
+       data-ng-repeat="md in searchResults.records"
+       data-gn-fix-mdlinks=""
+       data-gn-displayextent-onhover=""
+       data-gn-zoomto-onclick="">
 
-     <div title="{{(md.abstract || md.defaultAbstract) | striptags}}"
-         data-ng-click="openRecord($index, md, searchResults.records)">
-      <!-- Thumbnail -->
-      <div class="gn-md-thumbnail">
-        <img class="gn-img-thumbnail"
-             data-ng-src="{{md.getThumbnails().list[0].url}}"
-             data-ng-if="md.getThumbnails().list[0].url"/>
+      <div title="{{(md.abstract || md.defaultAbstract) | striptags}}"
+          data-ng-click="openRecord($index, md, searchResults.records)">
+       <!-- Thumbnail -->
+       <div class="gn-md-thumbnail">
+         <img class="gn-img-thumbnail"
+              data-ng-src="{{md.getThumbnails().list[0].url}}"
+              data-ng-if="md.getThumbnails().list[0].url"/>
 
-        <!-- Display the first metadata status (apply to ISO19139 record) -->
-        <div data-ng-if="md.status_text.length > 0"
-             title="{{md.status_text[0]}}"
-             class="gn-status gn-status-{{md.status[0]}}">{{md.status_text[0]}}
-        </div>
+         <!-- Display the first metadata status (apply to ISO19139 record) -->
+         <div data-ng-if="md.status_text.length > 0"
+              title="{{md.status_text[0]}}"
+              class="gn-status gn-status-{{md.status[0]}}">{{md.status_text[0]}}
+         </div>
+       </div>
       </div>
-     </div>
-    </li>
-  </ul>
+     </li>
+   </ul>
 
 We can define any class we want and reference it on the gn_search_default.css file to give it some styling.

--- a/source/tutorials/index.rst
+++ b/source/tutorials/index.rst
@@ -10,3 +10,4 @@ Tutorials
    introduction/index.rst
    customui/index.rst
    hookcustomizations/index.rst
+   inspire/index

--- a/source/tutorials/inspire/index.rst
+++ b/source/tutorials/inspire/index.rst
@@ -1,10 +1,9 @@
 .. _tutorials_inspire:
 
 Tutorials
-##########
+#########
 
-The tutorials in this section target specific GeoNetwork implementation scenarios related to the `European INSPIRE Directive <http://inspire.ec.europa.eu/>`_. INSPIRE mandates European organisations to set up view- and download services and to describe them using metadata in discovery services. To respond to all aspects of the technical guidelines requires to compose an infrastructure of various components. For now we provide tutorials for view services in `mapserver <view-mapserver.rst>`_ and `geoserver <view-geoserver.rst>`_ and download services using `Atom <download-atom.rst>`_ and `geoserver <download-geoserver.rst>`_.
-
+The tutorials in this section target specific GeoNetwork implementation scenarios related to the `European INSPIRE Directive <http://inspire.ec.europa.eu/>`__. INSPIRE mandates European organisations to set up view- and download services and to describe them using metadata in discovery services. To respond to all aspects of the technical guidelines requires to compose an infrastructure of various components. For now we provide tutorials for view services in :doc:`mapserver <view-mapserver>` and :doc:`geoserver <view-geoserver>` and download services using :doc:`Atom <download-atom>` and :doc:`geoserver <download-geoserver>`.
 
 .. toctree::
    :maxdepth: 2

--- a/source/tutorials/inspire/view-mapserver.rst
+++ b/source/tutorials/inspire/view-mapserver.rst
@@ -8,27 +8,26 @@ This tutorial shows how one can set up a combination of `MapServer <http://mapse
 MapServer
 =========
 
-How to set up an INSPIRE view service in Mapserver is documented in `mapserver documentation <http://www.mapserver.org/ogc/inspire.html>`_. In this tutorial we use the reference service metadata approach:
+How to set up an INSPIRE view service in Mapserver is documented in `mapserver documentation <http://www.mapserver.org/ogc/inspire.html>`__. In this tutorial we use the reference service metadata approach:
 
-.. code-block::
+.. code-block:: text
 
- WEB
-  METADATA
-   "wms_inspire_capabilities" "url"
-  END
- END
-
+   WEB
+    METADATA
+     "wms_inspire_capabilities" "url"
+    END
+   END
 
 GeoNetwork
 ==========
 
-When deploying Geonetwork, make sure the GEMET thesauri are loaded and activate the INSPIRE editor as described in `Geonetwork documentation <http://geonetwork-opensource.org/manuals/trunk/eng/users/administrator-guide/configuring-the-catalog/inspire-configuration.html>`_.
+When deploying Geonetwork, make sure the GEMET thesauri are loaded and activate the INSPIRE editor as described in :ref:`Geonetwork documentation <inspire-configuration>`.
 
 In Admin > Settings activate the INSPIRE extension.
 
 .. image:: img/image_3.png
 
-For each dataset that you are going to publish create an iso19115 record using the INSPIRE template. Link each record to the view service as created in mapserver: eg https://{url}/cgi-bin/mapserv?map={mapfile}&request=getcapabilities&service=wms&version=1.3.0
+For each dataset that you are going to publish create an iso19115 record using the INSPIRE template. Link each record to the view service as created in mapserver: eg `https://{url}/cgi-bin/mapserv?map={mapfile}&request=getcapabilities&service=wms&version=1.3.0`
 
 .. image:: img/image_5.png
 
@@ -41,38 +40,38 @@ Return to MapServer Mapfile
 
 For each layer configuration add a metadata url of type text/xml. Other relevant parameters are the authority element and the dataset identifier.
 
-.. code-block::
+.. code-block:: text
 
- LAYER
-  NAME "mylayer"
-  METADATA
-   wms_dataurl_format "application/vnd.ogc.csw.GetRecordByIdResponse_xml"
-   wms_dataurl_href "http://geonetwork/srv/api/records/f4f137aa-a2bf-4033-91ef-2cfdbe500690"
-   wms_authorityurl_name "inspire" 
-   wms_authorityurl_href "http://inspire.ec.europa.eu/"
-   wms_identifier_authority "inspire"
-   wms_identifier_value "0a636f43-016c-474a-ab28-1f3d75e9fcae"
-  END
- END
+   LAYER
+    NAME "mylayer"
+    METADATA
+     wms_dataurl_format "application/vnd.ogc.csw.GetRecordByIdResponse_xml"
+     wms_dataurl_href "http://geonetwork/srv/api/records/f4f137aa-a2bf-4033-91ef-2cfdbe500690"
+     wms_authorityurl_name "inspire" 
+     wms_authorityurl_href "http://inspire.ec.europa.eu/"
+     wms_identifier_authority "inspire"
+     wms_identifier_value "0a636f43-016c-474a-ab28-1f3d75e9fcae"
+    END
+   END
 
 For the service definition add a link to the service metadata
 
-.. code-block:: 
+.. code-block:: text
 
- WEB
-  METADATA
-   "wms_inspire_capabilities" "url"
-   "wms_languages" "eng"               
-   "wms_inspire_metadataurl_href" "http://geonetwork/srv/api/records/d461302e-5ec8-415d-9a6d-05de37184b03"
-   "wms_inspire_metadataurl_format" "application/vnd.ogc.csw.GetRecordByIdResponse_xml"
-   "wms_keywordlist_ISO_items" "infoMapAccessService"
-  END 
- END
+    WEB
+     METADATA
+      "wms_inspire_capabilities" "url"
+      "wms_languages" "eng"               
+      "wms_inspire_metadataurl_href" "http://geonetwork/srv/api/records/d461302e-5ec8-415d-9a6d-05de37184b03"
+      "wms_inspire_metadataurl_format" "application/vnd.ogc.csw.GetRecordByIdResponse_xml"
+      "wms_keywordlist_ISO_items" "infoMapAccessService"
+     END 
+    END
 
 Validate the implementation
 ===========================
 
-If you are running the above setup online, you can use the `pilot JRC INSPIRE validator <http://inspire-geoportal.ec.europa.eu/validator2/>`_. If the above setup is running locally, you can use `Esdin Test Framework <https://github.com/Geonovum/etf-test-projects-inspire>`_ to validate the INSPIRE setup. 
+If you are running the above setup online, you can use the `pilot JRC INSPIRE validator <http://inspire-geoportal.ec.europa.eu/validator2/>`__. If the above setup is running locally, you can use `Esdin Test Framework <https://github.com/Geonovum/etf-test-projects-inspire>`__ to validate the INSPIRE setup. 
 
 .. image:: img/image_6.png
 
@@ -81,5 +80,5 @@ Running the test frequently during development helps to identify issues in an ea
 Known issues
 ============
 
-There is a known issue in the capabilities to metadata linkage. The JRC validator requires a gmd:RS_Identifier inside gmd:code having the authority and dataset identifier modeled separately. However the technical guidelines suggest a gmd:MD_Identifier inside gmd:code, the authority can then be included as a prefix, eg < gmd:MD_Identifier >{authority}#{uuid}< gmd:MD_Identifier >
+There is a known issue in the capabilities to metadata linkage. The JRC validator requires a gmd:RS_Identifier inside gmd:code having the authority and dataset identifier modeled separately. However the technical guidelines suggest a gmd:MD_Identifier inside gmd:code, the authority can then be included as a prefix, eg `<gmd:MD_Identifier>{authority}#{uuid}<gmd:MD_Identifier>`
 

--- a/source/tutorials/introduction/deployment/build.rst
+++ b/source/tutorials/introduction/deployment/build.rst
@@ -1,4 +1,4 @@
-.. _tuto-introduction-deployment-build
+.. _tuto-introduction-deployment-build:
 
 (Optional) Build
 ################

--- a/source/user-guide/describing-information/inspire-editing.rst
+++ b/source/user-guide/describing-information/inspire-editing.rst
@@ -108,6 +108,7 @@ It can be forced globally in the editor by setting the ``transformations`` param
 Keywords can also be encoded in multilingual mode:
 
 .. code-block:: xml
+
         <gmd:descriptiveKeywords>
             <gmd:MD_Keywords>
                <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
@@ -188,6 +189,7 @@ On the coordinate of the bounding box, the INSPIRE validator may report errors d
 
 
 .. code-block:: xml
+
                   <gmd:EX_GeographicBoundingBox>
                      <gmd:northBoundLatitude>
                         <gco:Decimal>50.80</gco:Decimal>
@@ -200,6 +202,7 @@ Coordinate system
 Coordinate system using URI like http://www.opengis.net/def/crs/EPSG/0/3035. For example:
 
 .. code-block:: xml
+
        <gmd:referenceSystemInfo>
           <gmd:MD_ReferenceSystem>
              <gmd:referenceSystemIdentifier>

--- a/source/user-guide/publishing/transferring-privileges.rst
+++ b/source/user-guide/publishing/transferring-privileges.rst
@@ -1,7 +1,7 @@
 .. _transferring-privileges:
 
 Transferring privileges
-######################
+#######################
 
 Transfer Ownership
 ------------------
@@ -10,19 +10,16 @@ When metadata ownership needs to be transferred from one user to another for all
 
 .. figure:: img/transfer.png
 
-    *How to open the Transfer Ownership page*
+   *How to open the Transfer Ownership page*
 
 It is located in the "actions on selected set" in the search result and once selected, opens the following panel.
 
 .. figure:: img/dotransfer.png
 
-    *The Transfer Ownership panel*
+   *The Transfer Ownership panel*
 
-#. *Select New Owner*: Select a user in this auto-complete.
+* :guilabel:`Select New Owner`: Select a user in this auto-complete.
 
-.. note:: The drop down will be filled with all Editors visible to you. If you are not an Administrator, you will view only a subset of all Editors.
+  .. note:: The drop down will be filled with all Editors visible to you. If you are not an Administrator, you will view only a subset of all Editors.
 
-#. *Select group*: Select one of the groups this user is a member of. Privileges to groups All and Intranet are not transferable.
-
-
-
+* :guilabel:`Select group`: Select one of the groups this user is a member of. Privileges to groups All and Intranet are not transferable.

--- a/source/user-guide/workflow/batchediting.rst
+++ b/source/user-guide/workflow/batchediting.rst
@@ -44,12 +44,10 @@ To add an element, eg. add a new keyword section in first position:
 
 .. code-block:: json
 
-  [{
-    "xpath": "/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords[1]",
-    "value": "<gn_add><gmd:descriptiveKeywords xmlns:gmd=\"http://www.isotc211.org/2005/gmd\" xmlns:gco=\"http://www.isotc211.org/2005/gco\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>Waste water</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\"./resources/codeList.xml#MD_KeywordTypeCode\" codeListValue=\"theme\"/></gmd:type></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>"
-    }]
-
-
+   [{
+     "xpath": "/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords[1]",
+     "value": "<gn_add><gmd:descriptiveKeywords xmlns:gmd=\"http://www.isotc211.org/2005/gmd\" xmlns:gco=\"http://www.isotc211.org/2005/gco\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>Waste water</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\"./resources/codeList.xml#MD_KeywordTypeCode\" codeListValue=\"theme\"/></gmd:type></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>"
+   }]
 
 To remove an element, eg. remove all online resource having a protocol ``OGC:WMS``:
 
@@ -66,11 +64,10 @@ To replace an element, eg. replacing a keyword value:
 
 .. code-block:: json
 
-  [{
-    "xpath":".//gmd:keyword/gco:CharacterString[text() = 'wastewater']",
-    "value":"<gn_replace>Waste water</gn_replace>"
-  }]
-
+   [{
+     "xpath":".//gmd:keyword/gco:CharacterString[text() = 'wastewater']",
+     "value":"<gn_replace>Waste water</gn_replace>"
+   }]
 
 .. figure:: img/batch-editing-replace.png
 
@@ -100,23 +97,23 @@ Add a new keyword sections in identification
 
 * XPath (the parent element of the XML snippet to add). The XML is inserted in the position defined in the XSD.
 
-.. code-block:: xpath
+  .. code-block:: xslt
 
-  .//srv:SV_ServiceIdentification
+    .//srv:SV_ServiceIdentification
 
 * XML
 
-.. code-block:: xml
+  .. code-block:: xml
 
-  <mri:descriptiveKeywords xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
-                           xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
-                           xmlns:xlink="http://www.w3.org/1999/xlink">
-    <mri:MD_Keywords>
-      <mri:keyword>
-        <gcx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoMapAccessService">Service d’accès aux cartes</gcx:Anchor>
-      </mri:keyword>
-    </mri:MD_Keywords>
-  </mri:descriptiveKeywords>
+    <mri:descriptiveKeywords xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
+                             xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
+                             xmlns:xlink="http://www.w3.org/1999/xlink">
+      <mri:MD_Keywords>
+        <mri:keyword>
+          <gcx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoMapAccessService">Service d’accès aux cartes</gcx:Anchor>
+        </mri:keyword>
+      </mri:MD_Keywords>
+    </mri:descriptiveKeywords>
 
 
 Replace a keyword section encoded using a CharacterString to an Anchor
@@ -127,53 +124,53 @@ Replace a keyword section encoded using a CharacterString to an Anchor
 
 * XPath (the parent element of the XML snippet to insert)
 
-.. code-block:: xpath
+  .. code-block:: xslt
 
-  .//mri:descriptiveKeywords[*/mri:keyword/gco:CharacterString/text() = 'infoMapAccessService']
+    .//mri:descriptiveKeywords[*/mri:keyword/gco:CharacterString/text() = 'infoMapAccessService']
 
 * XML
 
-.. code-block:: xml
+  .. code-block:: xml
 
-  <mri:MD_Keywords  xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
-                    xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
-                    xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
-                    xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
-                    xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
-                    xmlns:xlink="http://www.w3.org/1999/xlink">
-    <mri:keyword>
-      <gcx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoMapAccessService">Service d’accès aux cartes</gcx:Anchor>
-    </mri:keyword>
-    <mri:type>
-      <mri:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_KeywordTypeCode"
-                               codeListValue="theme"/>
-    </mri:type>
-    <mri:thesaurusName>
-       <cit:CI_Citation>
-          <cit:title>
-             <gcx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory#">Classification of spatial data services</gcx:Anchor>
-          </cit:title>
-          <cit:date>
-             <cit:CI_Date>
-                <cit:date>
-                   <gco:Date>2008-12-03</gco:Date>
-                </cit:date>
-                <cit:dateType>
-                   <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode"
-                                        codeListValue="publication"/>
-                </cit:dateType>
-             </cit:CI_Date>
-          </cit:date>
-          <cit:identifier>
-             <mcc:MD_Identifier>
-                <mcc:code>
-                   <gcx:Anchor xlink:href="http://metawal.wallonie.be/geonetwork/srv/fre/thesaurus.download?ref=external.theme.httpinspireeceuropaeumetadatacodelistSpatialDataServiceCategory-SpatialDataServiceCategory">geonetwork.thesaurus.external.theme.httpinspireeceuropaeumetadatacodelistSpatialDataServiceCategory-SpatialDataServiceCategory</gcx:Anchor>
-                </mcc:code>
-             </mcc:MD_Identifier>
-          </cit:identifier>
-       </cit:CI_Citation>
-    </mri:thesaurusName>
-  </mri:MD_Keywords>
+    <mri:MD_Keywords  xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
+                      xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
+                      xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
+                      xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
+                      xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
+                      xmlns:xlink="http://www.w3.org/1999/xlink">
+      <mri:keyword>
+        <gcx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoMapAccessService">Service d’accès aux cartes</gcx:Anchor>
+      </mri:keyword>
+      <mri:type>
+        <mri:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_KeywordTypeCode"
+                                 codeListValue="theme"/>
+      </mri:type>
+      <mri:thesaurusName>
+         <cit:CI_Citation>
+            <cit:title>
+               <gcx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory#">Classification of spatial data services</gcx:Anchor>
+            </cit:title>
+            <cit:date>
+               <cit:CI_Date>
+                  <cit:date>
+                     <gco:Date>2008-12-03</gco:Date>
+                  </cit:date>
+                  <cit:dateType>
+                     <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode"
+                                          codeListValue="publication"/>
+                  </cit:dateType>
+               </cit:CI_Date>
+            </cit:date>
+            <cit:identifier>
+               <mcc:MD_Identifier>
+                  <mcc:code>
+                     <gcx:Anchor xlink:href="http://metawal.wallonie.be/geonetwork/srv/fre/thesaurus.download?ref=external.theme.httpinspireeceuropaeumetadatacodelistSpatialDataServiceCategory-SpatialDataServiceCategory">geonetwork.thesaurus.external.theme.httpinspireeceuropaeumetadatacodelistSpatialDataServiceCategory-SpatialDataServiceCategory</gcx:Anchor>
+                  </mcc:code>
+               </mcc:MD_Identifier>
+            </cit:identifier>
+         </cit:CI_Citation>
+      </mri:thesaurusName>
+    </mri:MD_Keywords>
 
 Remove a keyword block
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -182,10 +179,10 @@ Remove a keyword block
 
 * XPath (the second descriptiveKeywords block corresponding to a thesaurus 'Champ géographique')
 
-.. code-block:: xpath
+  .. code-block:: xslt
 
-  (.//mri:descriptiveKeywords
-      [*/mri:thesaurusName/*/cit:title/gcx:Anchor = 'Champ géographique'])[2]
+    (.//mri:descriptiveKeywords
+        [*/mri:thesaurusName/*/cit:title/gcx:Anchor = 'Champ géographique'])[2]
 
 * XML (N/A)
 
@@ -196,9 +193,9 @@ Remove a keyword
 
 * XPath (All keyword with value 'IDP_reference')
 
-.. code-block:: xpath
+  .. code-block:: xslt
 
-  .//gmd:keyword[*/text() = 'IDP_reference']
+    .//gmd:keyword[*/text() = 'IDP_reference']
 
 * XML (N/A)
 
@@ -210,11 +207,9 @@ Remove associatedResource with a type partOfSeamlessDatabase only if it is a ser
 
 * XPath
 
+  .. code-block:: xslt
 
-.. code-block:: xpath
-
- .[mdb:metadataScope/*/mdb:resourceScope/*/@codeListValue = 'series']//mri:associatedResource[*/mri:associationType/*/@codeListValue = "partOfSeamlessDatabase"]
- 
+  .[mdb:metadataScope/*/mdb:resourceScope/*/@codeListValue = 'series']//mri:associatedResource[*/mri:associationType/*/@codeListValue = "partOfSeamlessDatabase"]
  
 * XML (N/A)
 


### PR DESCRIPTION
This PR acts as a safety measure on further documentation changes, and is useful to catch causal sphinx errors (often introduced when editing directly from github).

* [x] introduce use of `-W --keep-going` to enforce warnings
* [x] address sphinx documentation warnings

I found two pages to be rather troubled:

* `csw-configuration.rst` defined several references (used as link targets from the inspire page). Sphinx only allows references before a heading (as the heading text is used the link is used in another document.
  
  ```
  .. _reference:
  
  heading
  -------- 
  ```
  
  I introduced some headings to address these warnings, and had to work on page order so the result would make sense.  

* The page `creating-custom-editor.rst` had several code examples that broken due to indentation. The page structure also made use of nested bullet points to group content, and had a few references without headings.

I would prefer if this PR was reviewed and merged based on changes to the document structure. While there may be inaccuracies (or clarifications) desired for the document content ... they are not the subject of this PR.