### PR TITLE
DOI / Add more details about the mapping

### DIFF
--- a/source/user-guide/associating-resources/doi.rst
+++ b/source/user-guide/associating-resources/doi.rst
@@ -38,6 +38,7 @@ For DOI creation, the task is a 2 steps actions:
 
 The DataCite format requires some mandatory fields:
 
+
  * Identifier (with mandatory type sub-property)
 
  * Creator (with optional given name, family name, name identifier and affiliation sub-properties)
@@ -49,6 +50,27 @@ The DataCite format requires some mandatory fields:
  * PublicationYear
 
  * ResourceType (with mandatory general type description subproperty)
+
+
+The mapping with ISO standards is the following:
+
+.. csv-table::
+   :header: "Property", "ISO 19139", "ISO 19115-3"
+   :widths: 10, 40, 40
+
+   "Identifier", "gmd:MD_Metadata/gmd:fileIdentifier/\*/text()", "mdb:MD_Metadata/mdb:metadataIdentifier/\*/mcc:code/\*/text()"
+   "Creator", "gmd:identificationInfo/\*/gmd:pointOfContact with role 'pointOfContact' or 'custodian'", "mdb:identificationInfo/\*/mri:pointOfContact with role 'pointOfContact' or 'custodian'"
+   "Title", "gmd:identificationInfo/\*/gmd:citation/\*/gmd:title", "mdb:identificationInfo/\*/mri:citation/\*/cit:title"
+   "Publisher", "gmd:distributorContact[1]/\*/gmd:organisationName/gco:CharacterString", "mrd:distributorContact[1]/\*/cit:party/\*/cit:organisationName/gco:CharacterString"
+   "PublicationYear", "gmd:identificationInfo/\*/gmd:citation/\*/gmd:date/\*[gmd:dateType/\*/\@codeListValue = 'publication']", "mdb:identificationInfo/\*/mri:citation/\*/cit:date/\*[cit:dateType/\*/\@codeListValue = 'publication']"
+   "ResourceType", "gmd:hierarchyLevel/\*/\@codeListValue", "mdb:metadataScope/\*/mdb:resourceScope/\*/\@codeListValue"
+
+
+The mapping can be customized in:
+
+* ISO19139 :code:`schemas/iso19139/src/main/plugin/iso19139/formatter/datacite/view.xsl`
+
+* ISO19115-3.2018 :code:`schemas/iso19139/src/main/plugin/iso19139/formatter/datacite/view.xsl`
 
 
 See http://schema.datacite.org/meta/kernel-4.1/doc/DataCite-MetadataKernel_v4.1.pdf for more details on the format.


### PR DESCRIPTION
Quite often when requesting DOI creation an XSD error like 

```
Record 'b1f1e0be-f2de-4265-b94a-78e70c5db1cb' converted to DataCite format is invalid. 
Error is: XSD Validation error(s): <xsderrors> <error> <typeOfError>ERROR</typeOfError> 
<errorNumber>1</errorNumber> <message>cvc-complex-type.2.4.b: The content of element
 'datacite:resource' is not complete. One of '{"http://datacite.org/schema/kernel-4":publisher, "http://datacite.org/schema/kernel-4":publicationYear, "http://datacite.org/schema/kernel-4":
contributors, "http://datacite.org/schema/kernel-4":alternateIdentifiers,
"http://datacite.org/schema/kernel-4":relatedIdentifiers, "http://datacite.org/schema/kernel-4":sizes, "http://datacite.org/schema/kernel-4":formats, 
"http://datacite.org/schema/kernel-4":rightsList, "http://datacite.org/schema/kernel-4":fundingReferences}'
 is expected. (Element: datacite:resource with parent element: Unknown)</message> 
<xpath>.</xpath> </error> </xsderrors>. 
Required fields in DataCite are: identifier, creators, titles, publisher, publicationYear, resourceType.
Check the DataCite format output at https://catalogue.georisques.gouv.fr:/geonetwork/srv/api/records/b1f1e0be-f2de-4265-b94a-78e70c5db1cb/formatters/datacite?output=xml and adpat the record content to add missing information.
 ```
is reported.

It may be hard for the user to find which mandatory field is missing. It depends on the mapping. 

Add a table with the mapping for mandatory field for ISO19139 and ISO19115-3.2018.