### PR TITLE
Fix environment variable name for authentication method

### DIFF
--- a/source/administrator-guide/managing-users-and-groups/authentication-mode.rst
+++ b/source/administrator-guide/managing-users-and-groups/authentication-mode.rst
@@ -13,7 +13,7 @@ However there are some other authentication mechanisms available:
 - :ref:`authentication-keycloak`
 - :ref:`authentication-shibboleth`
 
-Which mode to use is configured in :file:`WEB-INF/config-security/config-security.xml` or via an environment variable ``config.security.type``.
+Which mode to use is configured in :file:`WEB-INF/config-security/config-security.xml` or via an environment variable ``geonetwork.security.type``.
 
 Uncomment the relevant line in :file:`WEB-INF/config-security/config-security.xml`:
 


### PR DESCRIPTION
According to the authentication / security config xml, the environment variable used to determine the authentication method is called `geonetwork.security.type` instead of `config.security.type`:

https://github.com/geonetwork/core-geonetwork/blob/a1116fd98d057589790697b1ecde8ae4a5c7c2f5/web/src/main/webapp/WEB-INF/config-security/config-security.xml#L36-L66

I fixed that in the documentation. 