### PR TITLE
Mention config options so WAR-file doesn't need to be modified

### DIFF
--- a/source/install-guide/configuring-database.rst
+++ b/source/install-guide/configuring-database.rst
@@ -31,7 +31,7 @@ is created:
 Configuring a database via config files
 ---------------------------------------
 
-The database dialect is configured in :file:`/WEB-INF/config-node/srv.xml`. Uncomment the dialect to use. 
+The database dialect is configured in :file:`/WEB-INF/config-node/srv.xml`. Uncomment the dialect to use or use Java System property to configure it with `-Dgeonetwork.db.type=postgres` as described in https://github.com/geonetwork/core-geonetwork/blob/4.2.7/web/src/main/webResources/WEB-INF/config-node/srv.xml#L36.
 
 A jdbc driver is included for PostgreSQL, Oracle and H2. Other dialects require a jdbc driver to be installed.
 Download the jdbc library for the dialect and place it in ``/WEB-INF/lib`` or in the tomcat or GeoNetwork lib folder.
@@ -97,6 +97,18 @@ Setting configuration properties via environment variables is common in containe
 
 Within PostgreSQL it is possible to configure `postgres` or `postgis`. In the latter case GeoNetwork will use spatial capabilities of PostGIS to filter metadata. 
 In the first case (and for other database dialects) a Shapefile is created for storage of metadata coverage.
+
+Alternative environment variables are also supported for non-container (WAR-file) environments:
+
+.. code-block:: text
+
+    GEONETWORK_DB_USERNAME=example
+    GEONETWORK_DB_PASSWORD=xxx
+    GEONETWORK_DB_NAME=example
+    GEONETWORK_DB_HOST=localhost
+    GEONETWORK_DB_PORT=5432
+
+Based on compile-time settings: https://github.com/geonetwork/core-geonetwork/blob/4.2.7/pom.xml#L1457-L1462
 
 Logging
 -------

--- a/source/install-guide/installing-index.rst
+++ b/source/install-guide/installing-index.rst
@@ -49,13 +49,13 @@ User may want to customize the index settings for example to change language con
 .. code-block:: shell
 
     cd $GN_DATA_DIRECTORY/config/index
-    curl -X DELETE http://localhost:9200/features
-    curl -X DELETE http://localhost:9200/records
-    curl -X DELETE http://localhost:9200/searchlogs
+    curl -X DELETE http://localhost:9200/gn-features
+    curl -X DELETE http://localhost:9200/gn-records
+    curl -X DELETE http://localhost:9200/gn-searchlogs
 
-    curl -X PUT http://localhost:9200/features -H 'Content-Type: application/json' -d @features.json
-    curl -X PUT http://localhost:9200/records -H 'Content-Type: application/json' -d @records.json
-    curl -X PUT http://localhost:9200/searchlogs -H 'Content-Type: application/json' -d @searchlogs.json
+    curl -X PUT http://localhost:9200/gn-features -H 'Content-Type: application/json' -d @features.json
+    curl -X PUT http://localhost:9200/gn-records -H 'Content-Type: application/json' -d @records.json
+    curl -X PUT http://localhost:9200/gn-searchlogs -H 'Content-Type: application/json' -d @searchlogs.json
 
 
 Install using Maven

--- a/source/install-guide/installing-index.rst
+++ b/source/install-guide/installing-index.rst
@@ -94,4 +94,15 @@ Update Elasticsearch connection details in ```WEB-INF/config.properties``` and r
     es.username=
     es.password=
 
+
+Alternatively these can also be configured as system environment variables:
+
+.. code-block:: shell
+
+    GEONETWORK_ES_HOST=localhost
+    GEONETWORK_ES_PROTOCOL=http
+    GEONETWORK_ES_PORT=9200
+    GEONETWORK_ES_USERNAME=
+    GEONETWORK_ES_PASSWORD=
+
 It is not needed nor recommended to open port 9200 to the outside. GeoNetwork is protecting the Elasticsearch instance exposing only the search API and taking care of user privileges.


### PR DESCRIPTION
Came across these system environment variables and Java system properties as config options in the codebase while setting up an instance. This way the configuration don't need to be in files inside the webapp, but can be provided to a prebuilt WAR-file.

Also updated the index-names for elastic search since they seem to be prefixed with `gn-` based on these pom.xml props: https://github.com/geonetwork/core-geonetwork/blob/4.2.7/pom.xml#L1502-L1507

Not sure if you are updating this documentation or the README here: https://github.com/geonetwork/core-geonetwork/blob/4.2.7/es/README.md since the README mentions the prefix.