### PR TITLE
Fix path for encryptor.properties file

### DIFF
--- a/source/maintainer-guide/updating/index.rst
+++ b/source/maintainer-guide/updating/index.rst
@@ -7,7 +7,7 @@ Since GeoNetwork 4.0.4, passwords stored in the database for the mail server, ha
 `Jasypt <http://www.jasypt.org/>`__.
 
 By default, a random encryption password is generated when GeoNetwork is started, if it is not already defined, and it
-is stored in the file :file:`/geonetwork/WEB-INF/data/config/encryptor/encryptor.properties`. If you have set the
+is stored in the file :file:`/geonetwork/WEB-INF/data/config/encryptor.properties`. If you have set the
 location of the data directory outside of the application, the file will be stored in this external location.
 Read more at :ref:`customizing-data-directory`.
 


### PR DESCRIPTION
Looks like the path doesn't have the extra folder that is documented. What I actually wanted to edit is the underlined section in the image, but I can't find where that part of the documentation is located:

![image](https://github.com/user-attachments/assets/10ced337-74cb-4f83-92d3-37525c0e3146)
